### PR TITLE
Remove $user->save() from example code

### DIFF
--- a/en/building-sites/client-proofing/security/user-groups.md
+++ b/en/building-sites/client-proofing/security/user-groups.md
@@ -59,7 +59,6 @@ _old_uri: "2.x/administering-your-site/security/user-groups"
 // Get modUser object
 $user = $modx->getObject('modUser', array('username' => $username));
 if( $user ){
-    $user->save();
     // Assign new user to User Group / Role
     $user->joinGroup('UserGroupNameOrId','OptionalRoleNameOrId');}
 ?>


### PR DESCRIPTION
I removed $user->save(); from the example code as it wasn't necessary.

## Description of improvements

Any specific reason for this change? If a recent change in the MODX core caused the change, please include a link to the relevant pull request. 

## Affected versions

Please make sure your pull request targets the **lowest** affected version. Mark other relevant versions with an X below.

- [x] 2.x (current)
- [ ] 3.x

## Relevant issues

If available, provide the link or ID of relevant issues so that they can be closed once your improvement has been merged.
