### PR TITLE
Added deleted resolve_hostnames and server_protocol settings

### DIFF
--- a/en/getting-started/maintenance/upgrading/3.0/system-settings.md
+++ b/en/getting-started/maintenance/upgrading/3.0/system-settings.md
@@ -8,9 +8,10 @@ MODX 3.0 cleaned up a significant number of old system settings and changed the 
 
 - `allow_tv_eval`, the `@EVAL` binding is no longer supported for TVs for security reasons [#13865](https://github.com/modxcms/revolution/pull/13865)
 - `compress_js_max_files`, `manager_js_zlib_output_compression`, `manager_js_cache_file_locking`, `manager_js_cache_max_age`, `manager_js_document_root` which were related to the old dynamic manager js minification [#13859](https://github.com/modxcms/revolution/pull/13859), [#14868](https://github.com/modxcms/revolution/pull/14868)
-- `upload_flash`, set `upload_files` or `upload_images` or the `allowedFileTypes` on the media source instead. [#14252](https://github.com/modxcms/revolution/pull/14252)
+- `editor_css_path` and `editor_css_selectors` have been removed [#14843](https://github.com/modxcms/revolution/pull/14843). These settings may be in by [TinyMCE](https://github.com/modxcms/TinyMCE/issues/30) or other third-party extras which may need to accommodate the setting not being available.)
 - `manager_language` [#13786](https://github.com/modxcms/revolution/pull/13786), replaced by automatic language detection and on-the-fly switching in the manager [#14046](https://github.com/modxcms/revolution/pull/14046). [Learn more about the manager language in 3.0](getting-started/maintenance/upgrading/3.0/manager-language)
-- `editor_css_path` and `editor_css_selectors` have been removed [#14843](https://github.com/modxcms/revolution/pull/14843). These settings may be in by [TinyMCE](https://github.com/modxcms/TinyMCE/issues/30) or other third-party extras which may need to accommodate the setting not being available. 
+- `resolve_hostnames` and `server_protocol` have been removed [#14877](https://github.com/modxcms/revolution/pull/14877). Deprecated settings from MODX Evolution.
+- `upload_flash`, set `upload_files` or `upload_images` or the `allowedFileTypes` on the media source instead. [#14252](https://github.com/modxcms/revolution/pull/14252
 
 ## Changed default values
 


### PR DESCRIPTION
## Description
Added deleted `resolve_hostnames` and `server_protocol` settings.
Sorted the order of the deleted settings alphabetically.

## Affected versions
Relevant to 3.x.

## Relevant issues
https://github.com/modxcms/revolution/pull/14877
