### PR TITLE
Wrong lexicon placeholder used

### DIFF
--- a/en/extras/simplesearch/simplesearch/containertpl.md
+++ b/en/extras/simplesearch/simplesearch/containertpl.md
@@ -13,13 +13,13 @@ This is the Chunk displayed with the &containerTpl property on the [SimpleSearch
 ``` php
 <p class="sisea-results">[[+resultInfo]]</p>
 
-<div class="sisea-paging"><span class="sisea-result-pages">[[%sisea.result_pages? &namespace=`sisea` &topic=`default`]]</span>[[+paging]]</div>
+<div class="sisea-paging"><span class="sisea-result-pages">[[%simplesearch.result_pages? &namespace=`sisea` &topic=`default`]]</span>[[+paging]]</div>
 
 <div class="sisea-results-list">
     [[+results]]
 </div>
 
-<div class="sisea-paging"><span class="sisea-result-pages">[[%sisea.result_pages? &namespace=`sisea` &topic=`default`]]</span>[[+paging]]</div>
+<div class="sisea-paging"><span class="sisea-result-pages">[[%simplesearch.result_pages? &namespace=`sisea` &topic=`default`]]</span>[[+paging]]</div>
 ```
 
 ## Available Placeholders


### PR DESCRIPTION
Default placeholder are `simplesearch.result_pages` and NOT `sisea.result_pages`

## Description

change a lexicon placeholder

## Affected versions

Is the change relevant to 2.x, 3.x?

## Relevant issues

none
