### PR TITLE
3x di container improvements

### DIFF
--- a/en/extending-modx/di-container/index.md
+++ b/en/extending-modx/di-container/index.md
@@ -51,7 +51,7 @@ The recommended way to inject or overwrite services in an extension is through a
 
 For example, you may call:
 
-``` php
+```php
 $modx->services->add('my_service', function($c) use ($modx) {
     return new MyPackage\MyService($modx);
 });
@@ -59,7 +59,7 @@ $modx->services->add('my_service', function($c) use ($modx) {
 
 You can use proper dependency injection by passing in the required services. Hypothetical example:
 
-``` php
+```php
 $modx->services->add('my_service', function($c) use ($modx) {
     return new MyPackage\MyService($c['sessions'], $c['parser']);
 });
@@ -67,7 +67,7 @@ $modx->services->add('my_service', function($c) use ($modx) {
 
 If you require a new instance to be returned for each service request, use the `factory()` method:
 
-``` php
+```php
 $modx->services->factory('my_service', function($c) use ($modx) {
     return new MyPackage\MyService($modx);
 });
@@ -75,7 +75,7 @@ $modx->services->factory('my_service', function($c) use ($modx) {
 
 To extend a previously defined service, use extend:
 
-``` php
+```php
 $modx->services->extend('existing_service', function($existing, $c) use ($modx) {
     $existing->...();
     return $existing;

--- a/en/extending-modx/di-container/index.md
+++ b/en/extending-modx/di-container/index.md
@@ -34,8 +34,8 @@ Or:
 ```php
 $service = null;
 try {
-    if ($modx->services->has('custom-service')) {
-        $service = $modx->services->get('custom-service');
+    if ($modx->services->has('custom_service')) {
+        $service = $modx->services->get('custom_service');
     }
 }
 catch (ContainerExceptionInterface $e) {
@@ -52,7 +52,7 @@ The recommended way to inject or overwrite services in an extension is through a
 For example, you may call:
 
 ``` php
-$modx->services->add('myservice', function($c) use ($modx) {
+$modx->services->add('my_service', function($c) use ($modx) {
     return new MyPackage\MyService($modx);
 });
 ```
@@ -60,7 +60,7 @@ $modx->services->add('myservice', function($c) use ($modx) {
 You can use proper dependency injection by passing in the required services. Hypothetical example:
 
 ``` php
-$modx->services->add('myservice', function($c) use ($modx) {
+$modx->services->add('my_service', function($c) use ($modx) {
     return new MyPackage\MyService($c['sessions'], $c['parser']);
 });
 ```
@@ -68,7 +68,7 @@ $modx->services->add('myservice', function($c) use ($modx) {
 If you require a new instance to be returned for each service request, use the `factory()` method:
 
 ``` php
-$modx->services->factory('myservice', function($c) use ($modx) {
+$modx->services->factory('my_service', function($c) use ($modx) {
     return new MyPackage\MyService($modx);
 });
 ```
@@ -76,7 +76,7 @@ $modx->services->factory('myservice', function($c) use ($modx) {
 To extend a previously defined service, use extend:
 
 ``` php
-$modx->services->extend('existing-service', function($existing, $c) use ($modx) {
+$modx->services->extend('existing_service', function($existing, $c) use ($modx) {
     $existing->...();
     return $existing;
 });

--- a/en/extending-modx/namespaces.md
+++ b/en/extending-modx/namespaces.md
@@ -18,7 +18,7 @@ For example, if a Namespace called "quip" has a path of "/www/modx/core/componen
 
 Namespaces can be used to isolate Lexicons and Lexicon Topics. For example, when loading a Lexicon, you can specify the Namespace of the topic prior to the name of the topic with a colon. For example, to load the "comment" topic for the "quip" Namespace:
 
-``` php
+```php
 $modx->lexicon->load('quip:comment');
 ```
 
@@ -41,19 +41,19 @@ In the `bootstrap.php` file, you have access to:
 
 To add a PSR4 autoloader pointing to the `src` directory in your namespace:
 
-```
+```php
 \MODX\Revolution\modX::getLoader()->addPsr4('My\\Component\\', $namespace['path'] . 'src/');
 ```
 
 To load an xPDO model:
 
-```
+```php
 $modx->addPackage('My\\Component\\Model', $namespace['path'] . 'src/', null, 'My\\Component\\');
 ```
 
 To register a service into the [dependency injection container](extending-modx/di-container):
 
-```
+```php
 $modx->services->add('my_service', function($c) use ($modx) {
     return new My\Component\MyService($modx);
 });

--- a/en/extending-modx/namespaces.md
+++ b/en/extending-modx/namespaces.md
@@ -54,7 +54,7 @@ $modx->addPackage('My\\Component\\Model', $namespace['path'] . 'src/', null, 'My
 To register a service into the [dependency injection container](extending-modx/di-container):
 
 ```
-$modx->services->add('myservice', function($c) use ($modx) {
+$modx->services->add('my_service', function($c) use ($modx) {
     return new My\Component\MyService($modx);
 });
 ```


### PR DESCRIPTION
## Description
Use snake case naming conventions for service identifiers to make it more consistent (various naming patterns where being used).
Add PHP code highlighting for code examples.

## Affected versions
3.x

## Relevant issues
None
