### PR TITLE
Tidy up example in table

### DIFF
--- a/en/extras/formit/formit.hooks/formitsaveform.md
+++ b/en/extras/formit/formit.hooks/formitsaveform.md
@@ -14,13 +14,12 @@ FormIt 3.0 introduces an update to the encryption methods used for encrypting fo
 
 It has the following properties to be passed into the FormIt snippet call:
 
-| name                                                                   | description                                                                                                                 |
-| ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| formName                                                               | The name of the form. Defaults to "form-{resourceid}".                                                                      |
-| formEncrypt                                                            | If is set to '1' _(true)_ the submitted form will be encrypted before saving inside the DB.                                 |
-| formFields                                                             | A comma-separated list of fields that will be saved. Defaults will save all fields including the submit button.             |
-| fieldNames                                                             | Change the name of the field inside the CMP. So if the field name is email2 you could change the name to "secondary email". |
-| Ex: &fieldnames=`fieldname==newfieldname, anotherone==anothernewname`. |
+| Name                                                                   | Description                                                                                                                 | Example                                                                |
+| ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| formName                                                               | The name of the form. Defaults to "form-{resourceid}".                                                                      | |
+| formEncrypt                                                            | If is set to '1' _(true)_ the submitted form will be encrypted before saving inside the DB.                                 | |
+| formFields                                                             | A comma-separated list of fields that will be saved. Defaults will save all fields including the submit button.             | |
+| fieldNames                                                             | Change the name of the field inside the CMP. So if the field name is email2 you could change the name to "secondary email". | &fieldnames=\`fieldname==Field display name,anotherone==Another field display name\` |
 
 ## See Also
 


### PR DESCRIPTION
Moving example to third column, capitalising column headings and updating fieldNames example to display backticks and show that the input 'new names' can contain spaces and casing if you'd like them to

## Description

Tidying up

## Affected versions

Both 2.x and 3.x?

## Relevant issues

Please link to any relevant issues or pull requests.
