### PR TITLE
Provides an alternative to @EVAL

### DIFF
--- a/en/extras/gallery/gallery/assinging-a-gallery-album-to-a-specifc-resource.md
+++ b/en/extras/gallery/gallery/assinging-a-gallery-album-to-a-specifc-resource.md
@@ -27,6 +27,7 @@ Input Option Values (just copy-paste the following code):
 ``` php
 $output = $modx->runSnippet("GalleryAlbums",array("rowTpl"=>"galleryDropdownList"))."none==0"; return $output;
 ```
+
 OR as an alternative to point 3 and 4, use this Select as Input Option Values (benefit: no need of @EVAL and no need of a chunk):
 
 ``` sql

--- a/en/extras/gallery/gallery/assinging-a-gallery-album-to-a-specifc-resource.md
+++ b/en/extras/gallery/gallery/assinging-a-gallery-album-to-a-specifc-resource.md
@@ -27,6 +27,10 @@ Input Option Values (just copy-paste the following code):
 ``` php
 $output = $modx->runSnippet("GalleryAlbums",array("rowTpl"=>"galleryDropdownList"))."none==0"; return $output;
 ```
+OR as an alternative to point 3 and 4, use this Select as Input Option Values (benefit: no need of @EVAL and no need of a chunk):
+```
+@SELECT GROUP_CONCAT(name, '==', id SEPARATOR '||') FROM `modx_gallery_albums` WHERE active=1
+```
 
 Default Value: 0
 

--- a/en/extras/gallery/gallery/assinging-a-gallery-album-to-a-specifc-resource.md
+++ b/en/extras/gallery/gallery/assinging-a-gallery-album-to-a-specifc-resource.md
@@ -28,7 +28,8 @@ Input Option Values (just copy-paste the following code):
 $output = $modx->runSnippet("GalleryAlbums",array("rowTpl"=>"galleryDropdownList"))."none==0"; return $output;
 ```
 OR as an alternative to point 3 and 4, use this Select as Input Option Values (benefit: no need of @EVAL and no need of a chunk):
-```
+
+``` sql
 @SELECT GROUP_CONCAT(name, '==', id SEPARATOR '||') FROM `modx_gallery_albums` WHERE active=1
 ```
 


### PR DESCRIPTION
Because @EVAL may become deprecated as of Modx 3.0 this @SELECT alternative could do the same job

## Description

This change has same effect as the @EVAL version but does neither need a chunk nor the evaluation of code

## Affected versions

2.x and 3.x

## Relevant issues