### PR TITLE
Update the 2.8.2 docs

### DIFF
--- a/en/getting-started/maintenance/upgrading/2.8.2.md
+++ b/en/getting-started/maintenance/upgrading/2.8.2.md
@@ -5,7 +5,7 @@ sortorder: 90
 
 The MODX 2.8.2 and 2.8.3 releases contain several security improvements, which may have an adverse effect on existing sites. This document details the potential impact and how to address them.
 
-> Note (May 2, 2021): The v2.8.2 release contained a few bugs addressed by the v2.8.3 release on May 28, 2021. Most notably [the ability to render static html was unintentionally removed](https://github.com/modxcms/revolution/issues/15696) and [rich text editors like TinyMCE could no longer render the media browser](https://github.com/modxcms/revolution/issues/15692). If you use these features, v2.8.3 resolves these regressions.
+> Note: The v2.8.2 release contained a few bugs. Most notably [the ability to render static html was unintentionally removed](https://github.com/modxcms/revolution/issues/15696) and [rich text editors like TinyMCE could no longer render the media browser](https://github.com/modxcms/revolution/issues/15692). These issues were fixed in v2.8.3, released on May 28th.
 
 ## Static resource paths
 
@@ -28,7 +28,7 @@ The core-provided "Administrator", "Content Editor" and "Developer" access polic
 
 ## `[[++table_prefix]]` in `@SELECT` TV options
 
-If you were using `[[++table_prefix]]` in TV options, replace it with `[[+PREFIX]]`. [#15695](https://github.com/modxcms/revolution/issues/15695)
+If you were using `[[++table_prefix]]` in TV options, in 2.8.2 this needs to be replaced with `[[+PREFIX]]`. [#15695](https://github.com/modxcms/revolution/issues/15695) In 2.8.3 the `[[++table_prefix]]` placeholder was restored. [#15714](https://github.com/modxcms/revolution/pull/15714) 
 
 ## Custom Manager Themes
 


### PR DESCRIPTION
## Description

Slight tweaks to simplify the language and note the table prefix works again in 2.8.3

## Affected versions

2.x

## Relevant issues

Please link to any relevant issues or pull requests.
