### PR TITLE
Add `_gitify| _backup` to protected directories

### DIFF
--- a/en/getting-started/maintenance/securing-modx.md
+++ b/en/getting-started/maintenance/securing-modx.md
@@ -31,21 +31,21 @@ For Apache, add the following to you `.htaccess` file:
 ```
 RewriteCond %{HTTP_HOST} ^(www\.)?example\.com$ [NC]
 # Block access to dotfiles and folder people have no need to touch
-RewriteRule ^(\.(?!well_known)|_build|core|config.core.php)  /index.php?q=doesnotexist [L,R=404]
+RewriteRule ^(\.(?!well_known)|_build|_gitify|_backup|core|config.core.php)  /index.php?q=doesnotexist [L,R=404]
 ```
 
 For NGINX, add the following to your web rules which will pass the rewrites to the MODX error handler:
 
 ```
-location ~ ^/(\.(?!well_known)|_build|core|config.core.php) {
-    rewrite ^/(\.(?!well_known)|_build|core|config.core.php) /index.php?q=doesnotexist;    
+location ~ ^/(\.(?!well_known)|_build|_gitify|_backup|core|config.core.php) {
+    rewrite ^/(\.(?!well_known)|_build|_gitify|_backup|core|config.core.php) /index.php?q=doesnotexist;    
 }
 ```
 
 If you have a high-traffic site, you might wish to bypass the PHP processing with MODX, and directly return a 404 from NGINX (or 444, which drops the connection without returning anything):
 
 ```
-location ~ ^/(\.(?!well_known)|_build|core|config.core.php) {
+location ~ ^/(\.(?!well_known)|_build|_gitify|_backup|core|config.core.php) {
     return 404;    
 }
 ```


### PR DESCRIPTION
## Description

Adds two potential fingerprinting directories to add to the list that should be "hidden" from the web

## Affected versions

3.x (though 2.x also, really)

## Relevant issues

n/a
