### PR TITLE
Update 3.0 server requirements

### DIFF
--- a/en/getting-started/server-requirements.md
+++ b/en/getting-started/server-requirements.md
@@ -9,13 +9,13 @@ MODX will run fine on most shared/cloud hosting, as well as VPS and dedicated bo
 
 | Component | Minimum            | Recommended                                     |
 | --------- | ------------------ | ----------------------------------------------- |
-| PHP       | 7.1                | 7.3 or higher                                      |
+| PHP       | 7.2                | 7.4 or higher, 8 supported                      |
 | Database  | Latest MySQL 5.6.x | MariaDB 10.1.x or Percona Server 5.6.x or above |
 | Webserver | *                  | NGINX 1.8 or Apache 2.4                         |
 
 ## PHP 
 
-MODX 3 requires at least PHP 7.1, but higher is recommended.
+MODX 3 requires at least PHP 7.2, but higher is recommended. PHP 8 is also supported.
 
 The following extensions are required by MODX, or are commonly required by extras: `zlib`, `json`, `gd`, `pdo` (specifically `pdo_mysql`), `imagick`, `simplexml`, `curl`, and `mbstring`. These are common extensions, and are usually enabled by default.
 
@@ -23,11 +23,13 @@ A `memory_limit` of at least 64M or higher is recommended.
 
 ## Database
 
-MODX supports different database drivers, including `mysql`, `sqlsrv`, and a third-party `postgres` implementation is available. It is important to note that extras also need to implement different drivers for their custom database tables, which is often only done for `mysql`, making that your best bet. 
+MODX supports a `mysql` database and a third-party `postgres` implementation is available. It is important to note that extras also need to implement different drivers for their custom database tables, which is often only done for `mysql`, making that your best bet. 
 
 The minimum supported MySQL version is 4.1.20, but 5.7 or up is recommended. It is also possible to use clusters like Galera. 
 
-Both MyISAM and InnoDB storage engines are supported, as are utf8 and utf8mb character sets.
+> Prior to MODX3, sqlsrv was also supported. [As that was practically unused, support for it has been removed in MODX 3.0.](https://github.com/modxcms/revolution/issues/15540)
+
+Both MyISAM and InnoDB storage engines are supported, as are utf8 and utf8mb character sets. It is recommended to use a utf8mb character set for widest UTF-8 support.
 
 The following permissions are required: `SELECT`, `INSERT`, `UPDATE`, `DELETE` for normal operations, `CREATE`, `ALTER`, `INDEX`, `DROP` for installations and upgrades of the core and installable extras, and `CREATE TEMPORARY TABLES` by some third party extras. 
 


### PR DESCRIPTION
## Description

Bumped to 7.2+ to use Flysystem v2 https://github.com/modxcms/revolution/pull/15757#issuecomment-871444299

Noted sqlsrv no longer supported

## Affected versions

3.x only

## Relevant issues


