### PR TITLE
Note sqlsrv support is deprecated and removed from 3.0 in relevant places

### DIFF
--- a/en/extending-modx/xpdo/custom-models/defining-a-schema/database-and-tables.md
+++ b/en/extending-modx/xpdo/custom-models/defining-a-schema/database-and-tables.md
@@ -30,7 +30,7 @@ First we'll tell the browser and parser that this is XML code with a standard XM
 
 - **package** - The name of the xPDO package (note this is different than a "transport package", a Revolution term). This is how xPDO separates different models and manages them. _Note: in the XML, the package name must be all lowercase._
 - **baseClass** - This is the base class from which all your class definitions will extend. Unless you're planning on creating a custom xPDOObject extension, it's best to leave it at the default.
-- **platform** — The database platform PDO driver you are using. At this time, xPDO supports mysql, sqlite, and sqlsrv PDO drivers.
+- **platform** — The database platform PDO driver you are using. At this time, xPDO supports mysql, sqlite, and sqlsrv PDO drivers. (Note: sqlsrv is no longer supported in MODX3.)
 - **defaultEngine** — The default engine of the database tables, usually either MyISAM or InnoDB. xPDO recommends using MyISAM.
 - **tablePrefix** — An optional parameter that can be set to override the default runtime table prefix. Useful for creating 3rd party components, but typically recommended to NOT define so the tablePrefix inherits from the MODX installation.
 - **phpdoc-package & phpdoc-subpackage** — These are custom attributes we're going to use in our map and class files. They're not standard xPDO attributes, but show that you can put whatever you want as attributes.

--- a/en/getting-started/installation/standard.md
+++ b/en/getting-started/installation/standard.md
@@ -72,6 +72,8 @@ If you have your MySQL server on a different port, specify it like so: "my.datab
 
 ### Microsoft SQL Server Notes
 
+> Important: sqlsrv support is deprecated and has been removed from MODX 3.0.
+
 Support for Microsoft SQL Server was introduced in MODX Revolution 2.1  Depending on your SQL Server's network configuration, there are different ways you may specify your host.
 
 - Named pipe: (local)/SQLEXPRESS

--- a/en/getting-started/server-requirements.md
+++ b/en/getting-started/server-requirements.md
@@ -26,7 +26,9 @@ A `memory_limit` of at least 64M or higher is recommended.
 
 MODX supports different database drivers, including `mysql`, `sqlsrv`, and a third-party `postgres` implementation is available. It is important to note that extras also need to implement different drivers for their custom database tables, which is often only done for `mysql`, making that your best bet.
 
-The minimum supported MySQL version is 4.1.20, but 5.6 or up is recommended. It is also possible to use clusters like Galera.
+> Note: sqlsrv support is deprecated and [has been removed in 3.0](https://github.com/modxcms/revolution/issues/15540).   
+
+The minimum supported MySQL version is 4.1.20, but 5.6 or up is strongly recommended. It is also possible to use clusters like Galera.
 
 Both MyISAM and InnoDB storage engines are supported, as are utf8 and utf8mb character sets.
 


### PR DESCRIPTION
## Description

Note sqlsrv support is deprecated and removed from 3.0 in relevant places

## Affected versions

2.x, can be merged into 3.x later but may conflict with 

## Relevant issues

https://github.com/modxcms/revolution/issues/15540
#358 
