### PR TITLE
Typo on [[!+page.nav]] placeholder

### DIFF
--- a/en/extras/getresources/index.md
+++ b/en/extras/getresources/index.md
@@ -337,7 +337,7 @@ Grab first 10 Resources - sorted by publishedon - below the Resource ID 17, no m
 ]]
 <div class="paging">
     <ul class="pageList">
-        [!+page.nav]]
+        [[!+page.nav]]
     </ul>
 </div>
 ```


### PR DESCRIPTION
Typo on [[!+page.nav]] placeholder. Missing opening bracket.

## Description

What does this change, and why is the change needed? 

## Affected versions

Is the change relevant to 2.x, 3.x, or both?

## Relevant issues

Please link to any relevant issues or pull requests.
