### PR TITLE
Aligned PHP version with min of 7.2

### DIFF
--- a/en/getting-started/upgrading-to-3.0/breaking-changes.md
+++ b/en/getting-started/upgrading-to-3.0/breaking-changes.md
@@ -11,7 +11,7 @@ As a major release, MODX 3.0 comes with a number of breaking changes. There is a
 
 The biggest breaking changes can be summarised as follows:
 
-- [Minimum supported PHP version has been increased to 7.1](getting-started/upgrading-to-3.0/requirements)
+- [Minimum supported PHP version has been increased to 7.2](getting-started/upgrading-to-3.0/requirements)
 - [It's no longer possible to use a custom core folder/path](getting-started/upgrading-to-3.0/core-folder)
 - [sqlsrv support has been removed](getting-started/upgrading-to-3.0/sqlsrv)
 - [A large number of (previously unnamespaced) classes have been renamed and moved](getting-started/upgrading-to-3.0/class-names), including processors and model classes.


### PR DESCRIPTION
Updated Minimum version of PHP to 7.2 as the build doesn't work on PHP 7.1 or below. Also the upgrading requirements page had already 7.2 listed.

## Description

Fixed Min PHP version to be aligned with actual and other docs. 

## Affected versions

Is the change relevant to 2.x, 3.x, or both?

3.0

## Relevant issues

NA


