### PR TITLE
Register custom hook for activation email attach

### DIFF
--- a/en/extras/login/login.tutorials/using-pre-and-post-hooks.md
+++ b/en/extras/login/login.tutorials/using-pre-and-post-hooks.md
@@ -115,6 +115,24 @@ Then we'd adjust our Register snippet call to load the postHook:
 
 And we're done!
 
+### Register custom hook for activation email attach
+
+What if you want to attach some document to newly registered user activation email? It's easy to do this also via `prehook`, just create snippet (let's name it `attachFile`) of something like the following code:
+
+```php
+// it can be a list/array of files and even passed to the hook from the outside. This example will be limited to a single hard-fixed file
+
+$attachment = 'relative_file_path.pdf';
+$hook->modx->getService('mail', 'mail.modPHPMailer');
+$hook->modx->mail->mailer->AddAttachment(MODX_BASE_PATH.$attachment);
+return true;
+```
+and  mention it in `Register` snippet call:
+
+```php
+[[!Register? &preHooks=`attachFile`]]
+```
+
 ### Profile logo update custom postHook
 
 First of all extend [UpdateProfile](https://docs.modx.com/current/en/extras/login/login.updateprofile#the-updateprofile-form) HTML form with next field:
@@ -188,7 +206,6 @@ and after add it to `UpdateProfile` snippet `preHooks` parameter:
 ```php
 [[!UpdateProfile? &preHooks=`hookUpdateProfilePhoto`]]
 ```
-
 
 ## See Also
 

--- a/en/extras/login/login.tutorials/using-pre-and-post-hooks.md
+++ b/en/extras/login/login.tutorials/using-pre-and-post-hooks.md
@@ -1,7 +1,6 @@
 ---
 title: "Login.Using Pre and Post Hooks"
-_old_id: "917"
-_old_uri: "revo/login/login.tutorials/login.using-pre-and-post-hooks"
+description: "Login hooks are basically Snippets that run after the form is validated"
 ---
 
 ## Hooking it Up with Login
@@ -126,6 +125,7 @@ $attachment = 'relative_file_path.pdf';
 $hook->modx->getService('mail', 'mail.modPHPMailer');
 $hook->modx->mail->mailer->AddAttachment(MODX_BASE_PATH.$attachment);
 return true;
+
 ```
 and  mention it in `Register` snippet call:
 

--- a/en/extras/login/login.tutorials/using-pre-and-post-hooks.md
+++ b/en/extras/login/login.tutorials/using-pre-and-post-hooks.md
@@ -119,7 +119,7 @@ And we're done!
 
 What if you want to attach some document to newly registered user activation email? It's easy to do this also via `prehook`, just create snippet (let's name it `attachFile`) of something like the following code:
 
-```php
+``` php
 // it can be a list/array of files and even passed to the hook from the outside. This example will be limited to a single hard-fixed file
 
 $attachment = 'relative_file_path.pdf';
@@ -129,7 +129,7 @@ return true;
 ```
 and  mention it in `Register` snippet call:
 
-```php
+``` php
 [[!Register? &preHooks=`attachFile`]]
 ```
 

--- a/en/extras/login/login.tutorials/using-pre-and-post-hooks.md
+++ b/en/extras/login/login.tutorials/using-pre-and-post-hooks.md
@@ -125,8 +125,8 @@ $attachment = 'relative_file_path.pdf';
 $hook->modx->getService('mail', 'mail.modPHPMailer');
 $hook->modx->mail->mailer->AddAttachment(MODX_BASE_PATH.$attachment);
 return true;
-
 ```
+
 and  mention it in `Register` snippet call:
 
 ``` php


### PR DESCRIPTION
## Description

Useful example how to attach document(s) to activation email

## Affected versions

Both 2.x, 3.x.

## Relevant issues

None.
