### PR TITLE
tagLister lost link

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -2382,5 +2382,5 @@
     "/help/internationalization": "en/extending-modx/internationalization",
     "/help/namespaces": "en/extending-modx/namespaces",
     "/help/template+variables": "en/building-sites/elements/template-variables",
-    "/display/ADDON/tagLister": "en/extras/tagLister"
+    "/display/addon/taglister": "en/extras/taglister"
 }

--- a/redirects.json
+++ b/redirects.json
@@ -2381,5 +2381,6 @@
     "/help/properties+and+property+sets": "en/building-sites/properties-and-property-sets",
     "/help/internationalization": "en/extending-modx/internationalization",
     "/help/namespaces": "en/extending-modx/namespaces",
-    "/help/template+variables": "en/building-sites/elements/template-variables"
+    "/help/template+variables": "en/building-sites/elements/template-variables",
+    "/display/ADDON/tagLister": "en/extras/tagLister"
 }


### PR DESCRIPTION
## Description

tagLister lost link

## Affected versions

both 2.x, 3.x

## Relevant issues

No any
