### PR TITLE
add snippet binding docs

### DIFF
--- a/en/building-sites/elements/template-variables/bindings/eval-binding.md
+++ b/en/building-sites/elements/template-variables/bindings/eval-binding.md
@@ -9,4 +9,4 @@ The `@EVAL` binding was present in earlier versions of MODX and allowed executin
 
 Due to the related security concerns, this has been removed in 3.0.
 
-As an alternative, you can use a [@SELECT](building-sites/elements/template-variables/bindings/select-binding) or [@CHUNK](building-sites/elements/template-variables/bindings/chunk-binding) binding, where the latter could be used to for example run a snippet.
+As an alternative, you can use a [@SELECT](building-sites/elements/template-variables/bindings/select-binding),  [@CHUNK](building-sites/elements/template-variables/bindings/chunk-binding) or [@SNIPPET](building-sites/elements/template-variables/bindings/snippet-binding) binding, where the last two could be used to for example run a snippet.

--- a/en/building-sites/elements/template-variables/bindings/index.md
+++ b/en/building-sites/elements/template-variables/bindings/index.md
@@ -45,10 +45,11 @@ When placing @ bindings inside the "Default Value" field the returned value is u
 - [@RESOURCE](building-sites/elements/template-variables/bindings/resource-binding "RESOURCE Binding")
 - [@CHUNK](building-sites/elements/template-variables/bindings/chunk-binding "CHUNK Binding")
 - [@SELECT](building-sites/elements/template-variables/bindings/select-binding "SELECT Binding")
+- [@SNIPPET](building-sites/elements/template-variables/bindings/snippet-binding "SNIPPET Binding")
 - [@DIRECTORY](building-sites/elements/template-variables/bindings/directory-binding "DIRECTORY Binding")
 - [@INHERIT](building-sites/elements/template-variables/bindings/inherit-binding "INHERIT Binding")
 
-Certain extras, such as [getResources](/extras/getresources "getResources"), support @INLINE or `@FILE` bindings for their chunks.
+Certain extras, such as [getResources](/extras/getresources "getResources"), support `@INLINE` or `@FILE` bindings for their chunks.
 
 ## See Also
 

--- a/en/building-sites/elements/template-variables/bindings/snippet-binding.md
+++ b/en/building-sites/elements/template-variables/bindings/snippet-binding.md
@@ -11,6 +11,7 @@ The @SNIPPET Binding executes the specified MODX snippet. It should be used with
 ``` php
 @SNIPPET snippet_name [properties_as_json]
 ```
+
 Binds the variable to a snippet. Where snippet_name is the name of the snippet. The returned value is the output of the snippet.\
 The JSON formatted properties are optional and are passed as scriptProperties to the snippet.
 

--- a/en/building-sites/elements/template-variables/bindings/snippet-binding.md
+++ b/en/building-sites/elements/template-variables/bindings/snippet-binding.md
@@ -1,0 +1,67 @@
+---
+title: "SNIPPET Binding"
+---
+
+## What is the @SNIPPET Binding?
+
+The @SNIPPET Binding executes the specified MODX snippet. It should be used with careful security precautions.
+
+## Syntax
+
+``` php
+@SNIPPET snippet_name [properties_as_json]
+```
+Binds the variable to a snippet. Where snippet_name is the name of the snippet. The returned value is the output of the snippet.\
+The JSON formatted properties are optional and are passed as scriptProperties to the snippet.
+
+## Usage
+
+let's have a snippet `datefmt` with this code
+
+``` php
+<?php
+$locale = $modx->getOption('locale',$scriptProperties,'en_US');
+$pattern = $modx->getOption('pattern',$scriptProperties,'YYYY/MM/dd');
+
+$fmt = datefmt_create(
+    $locale,
+    IntlDateFormatter::FULL,
+    IntlDateFormatter::FULL,
+    null,
+    null,
+    $pattern
+);
+return datefmt_format($fmt, time());
+```
+
+In Default Text simply put a snippet name after the @SNIPPET tag:
+
+``` php
+@SNIPPET datefmt
+```
+
+``` php
+@SNIPPET datefmt {"locale":"de-DE","pattern":"EEEE, dd.MM.YYYY"}
+```
+
+## Examples
+
+### Showing Related Posts
+
+There's a whole page showing an example of using the SNIPPET binding to generate input-options: [Creating a multi-select box for related pages in your template](building-sites/tutorials/multiselect-related-pages "Creating a multi-select box for related pages in your template").
+
+### db-driven input-option-values by using migxLoopCollection
+
+Let's say we want to have a dropdown-box to select a user-id by username.\
+Requirements: MIGX installed.
+
+Then create a listbox TV with this input-options:
+
+``` php
+@SNIPPET migxLoopCollection {"classname":"modUser","tpl":"@CODE:[[+username]]==[[+id]]","outputSeparator":"||","wrapperTpl":"@CODE:-- select a user--==0||[[+output]]"}
+```
+
+## See Also
+
+- [Template Variables](building-sites/elements/template-variables "Template Variables")
+- [Bindings](building-sites/elements/template-variables/bindings "Bindings")

--- a/en/building-sites/elements/template-variables/index.md
+++ b/en/building-sites/elements/template-variables/index.md
@@ -58,6 +58,7 @@ Which would output:
     4. [INHERIT Binding](building-sites/elements/template-variables/bindings/inherit-binding)
     5. [RESOURCE Binding](building-sites/elements/template-variables/bindings/resource-binding)
     6. [SELECT Binding](building-sites/elements/template-variables/bindings/select-binding)
+    7. [SNIPPET Binding](building-sites/elements/template-variables/bindings/snippet-binding)
 3. [Template Variable Input Types](building-sites/elements/template-variables/input-types)
 4. [Template Variable Output Types](building-sites/elements/template-variables/output-types)
     1. [Date TV Output Type](building-sites/elements/template-variables/output-types/date)

--- a/en/building-sites/tutorials/multiselect-related-pages.md
+++ b/en/building-sites/tutorials/multiselect-related-pages.md
@@ -17,10 +17,10 @@ Next link the Template Variable to the template that needs it on the "Template A
 To fill the template variable with some values, we will need to write simple snippet\* and run it in the Input Options field. To do this we will be using what is known as an [@BINDING](building-sites/elements/template-variables/bindings "Bindings"). Add the following code to the Input Options field:
 
 ``` php
- @EVAL return $modx->runSnippet('listMyResources',array('parent' => 9));
+ @SNIPPET listMyResources {"parent":"9"}
 ```
 
-This makes use of the [@EVAL binding](building-sites/elements/template-variables/bindings/eval-binding "EVAL Binding") to wrap the rest of the input in an eval() PHP statement. This can be used to execute PHP, and therefore access the very powerful $modx object. We are then using that to use the runSnippet method which, well, runs a snippet, while passing the array in the second parameter as properties. In this case we are telling it that "parent" is equal to 9. The result of this snippet will then be returned - not echoed. This is needed to make sure it can be parsed and will not be placed on the page randomly.
+This makes use of the [@SNIPPET binding](building-sites/elements/template-variables/bindings/snippet-binding "SNIPPET Binding") to generate the input-options for that TV. This can be used to run MODX snippets. We pass the the snippet name as second and the properties as JSON to the third parameter. In this case we are telling it that "parent" is equal to 9.
 
 You probably don't have a snippet called listMyResources yet, so let's create it.
 


### PR DESCRIPTION
## Description

Adds docs for @SNIPPET binding, which was indroduced with MODX 3.x

## Affected versions

the change is relevant to 3.x

## Relevant issues

Please link to any relevant issues or pull requests.
