### PR TITLE
correct the base_help_url default

### DIFF
--- a/en/building-sites/settings/base_help_url.md
+++ b/en/building-sites/settings/base_help_url.md
@@ -5,7 +5,7 @@ description: "The base URL by which to build the Help links in the top right of 
 
 **Name**: Base Help URL  
 **Type**: Textfield  
-**Default**: <https://docs.modx.com/current/en/index>  
+**Default**: //docs.modx.com/help
 **Available In**: Revolution 2.1+
 
 The base URL by which to build the Help links in the top right of pages in the manager.


### PR DESCRIPTION
## Description

This changes the default value on the [base_help_url](https://docs.modx.com/3.x/en/building-sites/settings/base_help_url) system setting so that it is correct at least when compared with my newly installed 3.0.3-pl

## Affected versions

I know from my own installation that it is true for 3.x, I do not know about 2.x

## Relevant issues

Should close #454 
