### PR TITLE
Update index.md

### DIFF
--- a/en/extras/collections/index.md
+++ b/en/extras/collections/index.md
@@ -23,7 +23,7 @@ You can drag n drop Resources into a Collections container and if they don’t h
 
 ### General Settings
 
-![](screenshot-2014-11-25-15.35.06.png)
+![screenshot](screenshot-2014-11-25-15.35.06.png)
 
 - Set as default view - If "Yes", this Collections View Template (CVT) will be used as a last fallback.
 - Default for templates - This will be the default CVT for Resources using these MODX Templates. Can be overridden on a per-resource basis in the Collections vertical-tab of the Collections resource's Settings.

--- a/en/extras/collections/index.md
+++ b/en/extras/collections/index.md
@@ -145,6 +145,19 @@ getSelections is a wrapper Snippet for getResources, so it relies on getResource
 
 - New link's button label - Customize label text on the "New Link" button.
 
+### Use with pdoRessources
+Instead of getRessources it is also possible to use the snippet pdoPage from the extra pdoTools:
+
+``` php
+[[!pdoPage?
+    &elementClass=`modSnippet`
+    &element=`getSelections`
+    &getResourcesSnippet=`pdoResources`
+    &parents=`[[*id]]`
+    &tpl=`myTplChunk`
+]]
+```
+
 ## Additional Resources
 
 - [Collections: Customizable Views for Content Types](https://modx.com/blog/2014/09/30/collections-easily-customizable-admin-views-for-content-types/)

--- a/en/extras/collections/index.md
+++ b/en/extras/collections/index.md
@@ -146,6 +146,7 @@ getSelections is a wrapper Snippet for getResources, so it relies on getResource
 - New link's button label - Customize label text on the "New Link" button.
 
 ### Use with pdoRessources
+
 Instead of getRessources it is also possible to use the snippet pdoPage from the extra pdoTools:
 
 ``` php


### PR DESCRIPTION
adding example snippet for use with pdoTools

## Description

Adding an example snippet for the use of pdoTools - so it's not needed to install getRessources if pdoTools is already installed.

## Affected versions

Change relevant to 2.x and 3.x, I guess.

## Relevant issues

none
