### PR TITLE
Add missing index.md for FRED CMP docs

### DIFF
--- a/en/extras/fred/themer/cmp/index.md
+++ b/en/extras/fred/themer/cmp/index.md
@@ -1,0 +1,5 @@
+---
+title: "Manager Pages"
+---
+
+Manager Pages allow you to create and control the settings of your themes. More specifically these include Elements, Blueprints, Option Sets, RTE Configs, Themed Templates, Media Sources, etc.


### PR DESCRIPTION
## Description

The subsequent pages weren't showing up in the navigation because of the missing index.md

## Affected versions

It is affecting both 2.x and 3.x

## Relevant issues

n/a


I noticed this issue because the subsequent pages were showing up on the separate FRED Docs here: [https://modxcms.github.io/fred/cmp-elements.html](https://modxcms.github.io/fred/cmp-elements.html)

Are these separate FRED Docs synced with the Docs here in some way or are they maintained separately from each other?
