### PR TITLE
Document forceSelection option for listbox TVs

### DIFF
--- a/en/building-sites/elements/template-variables/input-types/index.md
+++ b/en/building-sites/elements/template-variables/input-types/index.md
@@ -237,6 +237,7 @@ Option 1==value1||Option 2==value2
 ```json
 {
     "allowBlank": "true",
+    "forceSelection": "false",
     "listWidth": "",
     "title": "",
     "typeAhead": "false",


### PR DESCRIPTION
## Description

Document the forceSelection option for listbox TVs so that we know how to use it in MIGX fields.

## Affected versions

2.x
