### PR TITLE
Update mailtrap.md

### DIFF
--- a/en/building-sites/sending-mail/mailtrap.md
+++ b/en/building-sites/sending-mail/mailtrap.md
@@ -1,18 +1,16 @@
 ---
-title: mailtrap.io
+title: Mailtrap
 ---
 
-[Mailtrap](https://mailtrap.io) is a service (free plan available) that you can use to "trap" emails, without actually sending them to their intended recipient. Instead they're shown to you in a user interface.
+[Mailtrap](https://mailtrap.io) is an email delivery platform for developer and product teams. It provides SMTP service (free plan available) that you can use to send transactional and bulk emails. 
 
-When working on a development site, it's useful to configure emails to use such a service to prevent accidentally sending test emails to actual customers. 
-
-After creating an account, you can find the credentials in the inbox settings. 
+After creating a Mailtrap account and verifying your sending domain, you can find your SMTP credentials in the Sending Domains section, under Integrations.
 
 In MODX, configure the following via System > System Settings:
 
-- `mail_smtp_hosts`: smtp.mailtrap.io
+- `mail_smtp_hosts`: live.smtp.mailtrap.io
 - `mail_smtp_port`: 587
-- `mail_smtp_user` and `mail_smtp_pass` are provided in the inbox settings in mailtrap. 
+- `mail_smtp_user` and `mail_smtp_pass` are provided in the inbox settings in Mailtrap. 
 - `mail_smtp_prefix`: tls
 
 [Also see the generic instructions for sending email with SMTP for further activation and testing instructions](building-sites/sending-mail)

--- a/en/building-sites/sending-mail/mailtrap.md
+++ b/en/building-sites/sending-mail/mailtrap.md
@@ -2,15 +2,46 @@
 title: Mailtrap
 ---
 
-[Mailtrap](https://mailtrap.io) is an email delivery platform for developer and product teams. It provides SMTP service (free plan available) that you can use to send transactional and bulk emails. 
+When working on your MODX site, it's useful to have a single platform to both test emails in development and send them reliably in production. We suggest using Mailtrap for this.
 
-After creating a Mailtrap account and verifying your sending domain, you can find your SMTP credentials in the Sending Domains section, under Integrations.
+[Mailtrap](https://mailtrap.io) is an email platform for developer and product teams. It provides both an SMTP Service for sending transactional and bulk emails and an Email Sandbox for testing emails (free plan available for both).
+
+## Email Sandbox
+[Email Sandbox](https://mailtrap.io/email-sandbox/) is a service that you can use to "trap" emails, without actually sending them to their intended recipient. Instead, they're shown to you in a user interface.
+
+After creating an account, you can find the credentials in the Email Sandbox > Sandboxes > your sandbox.
 
 In MODX, configure the following via System > System Settings:
+- `mail_smtp_hosts`: sandbox.smtp.mailtrap.io
+- `mail_smtp_port`: 587
+- `mail_smtp_user` and `mail_smtp_pass` are provided in the sandbox settings in Mailtrap. 
+- `mail_smtp_prefix`: tls
 
+## SMTP service
+
+To send emails with [Mailtrap's SMTP](https://mailtrap.io/email-sending/), the [generic instructions apply](building-sites/sending-mail), but here's how to configure Mailtrap specifically. 
+
+### Setup and verify your sending domain
+1. In your Mailtrap account, navigate to Sending Domains and click Add Domain
+2. Enter the domain name you want to send from (you must have access to its DNS records)
+3. Add the provided DNS records to your domain provider
+4. Click Verify DNS Records once all records are added
+5. Wait for the automatic domain review to complete (usually takes a few minutes)
+6. Once verified, you'll see a Verified badge next to your domain
+
+_Important note: Some domains may require additional compliance checks. If selected, you'll be asked to fill out a simple compliance form._
+
+### Get your SMTP credentials
+Once your domain is verified, navigate to Sending Domains, select your domain, and open the Integrations tab.
+
+Click Integrate under Transactional Stream (for automated emails) or Bulk Stream (for marketing campaigns).
+
+Toggle to SMTP to reveal your credentials.
+
+In MODX, configure the following via System > System Settings:
 - `mail_smtp_hosts`: live.smtp.mailtrap.io
 - `mail_smtp_port`: 587
-- `mail_smtp_user` and `mail_smtp_pass` are provided in the inbox settings in Mailtrap. 
+- `mail_smtp_user` and `mail_smtp_pass` are provided in Mailtrap's Integration settings. 
 - `mail_smtp_prefix`: tls
 
 [Also see the generic instructions for sending email with SMTP for further activation and testing instructions](building-sites/sending-mail)

--- a/en/building-sites/sending-mail/mailtrap.md
+++ b/en/building-sites/sending-mail/mailtrap.md
@@ -7,11 +7,13 @@ When working on your MODX site, it's useful to have a single platform to both te
 [Mailtrap](https://mailtrap.io) is an email platform for developer and product teams. It provides both an SMTP Service for sending transactional and bulk emails and an Email Sandbox for testing emails (free plan available for both).
 
 ## Email Sandbox
+
 [Email Sandbox](https://mailtrap.io/email-sandbox/) is a service that you can use to "trap" emails, without actually sending them to their intended recipient. Instead, they're shown to you in a user interface.
 
 After creating an account, you can find the credentials in the Email Sandbox > Sandboxes > your sandbox.
 
 In MODX, configure the following via System > System Settings:
+
 - `mail_smtp_hosts`: sandbox.smtp.mailtrap.io
 - `mail_smtp_port`: 587
 - `mail_smtp_user` and `mail_smtp_pass` are provided in the sandbox settings in Mailtrap. 
@@ -22,6 +24,7 @@ In MODX, configure the following via System > System Settings:
 To send emails with [Mailtrap's SMTP](https://mailtrap.io/email-sending/), the [generic instructions apply](building-sites/sending-mail), but here's how to configure Mailtrap specifically. 
 
 ### Setup and verify your sending domain
+
 1. In your Mailtrap account, navigate to Sending Domains and click Add Domain
 2. Enter the domain name you want to send from (you must have access to its DNS records)
 3. Add the provided DNS records to your domain provider
@@ -32,6 +35,7 @@ To send emails with [Mailtrap's SMTP](https://mailtrap.io/email-sending/), the [
 _Important note: Some domains may require additional compliance checks. If selected, you'll be asked to fill out a simple compliance form._
 
 ### Get your SMTP credentials
+
 Once your domain is verified, navigate to Sending Domains, select your domain, and open the Integrations tab.
 
 Click Integrate under Transactional Stream (for automated emails) or Bulk Stream (for marketing campaigns).
@@ -39,6 +43,7 @@ Click Integrate under Transactional Stream (for automated emails) or Bulk Stream
 Toggle to SMTP to reveal your credentials.
 
 In MODX, configure the following via System > System Settings:
+
 - `mail_smtp_hosts`: live.smtp.mailtrap.io
 - `mail_smtp_port`: 587
 - `mail_smtp_user` and `mail_smtp_pass` are provided in Mailtrap's Integration settings. 


### PR DESCRIPTION
We updated the Mailtrap product itself, and it's no longer a testing tool exclusively. This description is more accurate and still focuses on MODX's users' SMTP based email sending needs. Also updated 'smtp.mailtrap.io' to 'live.smtp.mailtrap.io'.

Trying again after previous PR received a comment about being promotional. Removed any possible fluff.

## Description

What does this change, and why is the change needed? 
Explained above.

## Affected versions

Is the change relevant to 2.x, 3.x, or both?

## Relevant issues

Please link to any relevant issues or pull requests.
https://github.com/modxorg/Docs/pull/548