### PR TITLE
Update glossary.md - fix Russian text in the Snippet definition

### DIFF
--- a/en/getting-started/glossary.md
+++ b/en/getting-started/glossary.md
@@ -186,7 +186,7 @@ Tags in the form `[[++SettingName]]` that reference MODX [System Settings](getti
 
 ## Snippet
 
-Способ, с помощью которого MODX позволяет вам запускать динамический код PHP на любой из ваших страниц. [Подробнее](building-sites/elements/snippets)
+The way in which MODX allows you to run dynamic PHP code on any of your pages. [Read more](building-sites/elements/snippets)
 
 ## Snippet Tags
 


### PR DESCRIPTION
Fix Russian text appearing in the Glossary for the Snippet definition

## Description

Russian text appears in the English glossary for the definition of "Snippet"

## Affected versions

It affects the documentation for both 2.x and 3.x.

## Relevant issues

Please link to any relevant issues or pull requests.
