### PR TITLE
docs(rest): Expand developing-restful-api for 2.x and 3.x

### DIFF
--- a/en/extending-modx/developing-restful-api.md
+++ b/en/extending-modx/developing-restful-api.md
@@ -149,11 +149,11 @@ That 405 means the router ran and found no matching controller. Next step: add c
 
 Map one path segment to one resource type. HTTP verbs do the work:
 
-- `GET /items` — list
-- `GET /items/15` — read primary key `15`
-- `POST /items` — create
-- `PUT /items/15` — update
-- `DELETE /items/15` — delete
+- `GET /items`: list
+- `GET /items/15`: read primary key `15`
+- `POST /items`: create
+- `PUT /items/15`: update
+- `DELETE /items/15`: delete
 
 Skip paths like `/items/create`. `POST /items` already means create.
 
@@ -254,7 +254,7 @@ Set these on your controller class to drive the default CRUD path:
 
 Default `get` / `post` / `put` / `delete` already handle the happy path. Override hooks when you need filters, permissions, or a different payload.
 
-**Before write/delete** — return `true` to continue, or `false` / an error string to abort:
+**Before write/delete**: return `true` to continue, or `false` / an error string to abort:
 
 - `beforePost()`
 - `beforePut()`
@@ -262,13 +262,13 @@ Default `get` / `post` / `put` / `delete` already handle the happy path. Overrid
 
 The object sits on `$this->object`.
 
-**After read/write** — `afterRead`, `afterPost`, `afterPut`, and `afterDelete` receive the outgoing array by reference. Change fields there before the response leaves.
+**After read/write**: `afterRead`, `afterPost`, `afterPut`, and `afterDelete` receive the outgoing array by reference. Change fields there before the response leaves.
 
 **List customisation:**
 
-- `prepareListQueryBeforeCount(xPDOQuery $c)` / `prepareListQueryAfterCount(xPDOQuery $c)` — add joins or `where` clauses
-- `prepareListObject(xPDOObject $object)` — map each row (default `toArray()`)
-- `addSearchQuery()` — override search behaviour
+- `prepareListQueryBeforeCount(xPDOQuery $c)` / `prepareListQueryAfterCount(xPDOQuery $c)`: add joins or `where` clauses
+- `prepareListObject(xPDOObject $object)`: map each row (default `toArray()`)
+- `addSearchQuery()`: override search behaviour
 
 **Helpers you call from overrides:**
 
@@ -344,6 +344,6 @@ Controllers may live in subfolders under `basePath`. The class name still uses t
 
 ## See also
 
-- [HTTP Client](extending-modx/services/http) — outbound requests from MODX 3
-- [modRest](extending-modx/services/modrest) — deprecated outbound client
-- [xPDO retrieving objects](extending-modx/xpdo/retrieving-objects) — query patterns you reuse in `prepareListQuery*`
+- [HTTP Client](extending-modx/services/http): outbound requests from MODX 3
+- [modRest](extending-modx/services/modrest): deprecated outbound client
+- [xPDO retrieving objects](extending-modx/xpdo/retrieving-objects): query patterns you reuse in `prepareListQuery*`

--- a/en/extending-modx/developing-restful-api.md
+++ b/en/extending-modx/developing-restful-api.md
@@ -4,69 +4,111 @@ _old_id: "1728"
 _old_uri: "2.x/developing-in-modx/advanced-development/developing-rest-servers"
 ---
 
-MODX 2.3 introduced a convenient method to develop RESTful APIs, on top of MODX. This is done with the modRestService class and modRestController derivatives and supports a whole lot of fancy features for interacting with xPDOObject instances. This document aims to provide you with the information you need to get started building your own API.
+MODX ships a small REST server stack built around `modRestService` and `modRestController`. You point HTTP requests at a bootstrap script, map URL paths to controller classes, and get CRUD behaviour over xPDO objects with hooks for auth, validation, and response shaping.
 
-## Recommended Pre-Development Reading
+This page covers MODX 2.3+ and MODX 3.x. Class locations changed in 3.x (`MODX\Revolution\Rest\*`). Behaviour of the service and controllers matches the examples below.
 
-Before building a RESTful API, it helps to know what a RESTful API really is and how they are supposed to work. There are a lot of resources available online, and Phil Sturgeon's " [Build APIs you won't hate](https://leanpub.com/build-apis-you-wont-hate)" is a great (e)book that can be useful to check out.
+> Outgoing HTTP from MODX to third-party APIs is a different stack. See [HTTP Client](extending-modx/services/http). The deprecated `modRest` client is documented under [Services](extending-modx/services/modrest).
 
-## In a Nutshell
+## Recommended reading
 
-1. Create an `index.php` file that handles the loading of MODX, setting up the REST Service with the right configuration and passing on the request to the controller (see #3).
-2. Create a `.htaccess` file that directs all requests (in a subfolder or on a specific domain) to the `index.php` from #1.
-3. Create controllers for each of your endpoints
+Phil Sturgeon's *[Build APIs you won't hate](https://leanpub.com/build-apis-you-wont-hate)* is a solid primer on REST conventions before you wire controllers.
+
+## In a nutshell
+
+1. Create `rest/index.php` that boots MODX, configures `modRestService`, then calls `prepare()` and `process()`.
+2. Route `/rest/*` to that script (Apache `.htaccess` inside `rest/`, or an nginx `location`).
+3. Add one controller class per endpoint under `rest/Controllers/`.
 
 ## 1. Bootstrapping the API
 
-The `modRestService` and `modRestController` classes will make your work a lot easier, but you do need to set up some basic code to hook it up. For this document, we will assume you are placing your API in a `/rest/` folder, adjust paths as necessary.
+Place the API under `/rest/` (adjust paths if you use another folder).
 
-First, create a `rest/index.php` file which looks something like this:
+### MODX 3.x
 
-``` php
+```php
 <?php
-// Boot up MODX
-require_once dirname(dirname(__FILE__)) . '/config.core.php';
-require_once MODX_CORE_PATH . 'model/modx/modx.class.php';
+use MODX\Revolution\modX;
+use MODX\Revolution\Rest\modRestService;
+
+require_once dirname(__DIR__) . '/config.core.php';
+require_once MODX_CORE_PATH . 'vendor/autoload.php';
+
 $modx = new modX();
 $modx->initialize('web');
-$modx->getService('error','error.modError', '', '');
-// Boot up any service classes or packages (models) you will need
-$path = $modx->getOption('mypackage.core_path', null,
-   $modx->getOption('core_path').'components/mypackage/') . 'model/mypackage/';
+$modx->getService('error', 'error.modError', '', '');
+
+$path = $modx->getOption(
+    'mypackage.core_path',
+    null,
+    $modx->getOption('core_path') . 'components/mypackage/'
+) . 'model/mypackage/';
+$modx->addPackage('mypackage', $path);
+
+$rest = new modRestService($modx, [
+    'basePath' => __DIR__ . '/Controllers/',
+    'controllerClassSeparator' => '',
+    'controllerClassPrefix' => 'MyController',
+    'xmlRootNode' => 'response',
+]);
+
+$rest->prepare();
+if (!$rest->checkPermissions()) {
+    $rest->sendUnauthorized(true);
+}
+$rest->process();
+```
+
+### MODX 2.x
+
+```php
+<?php
+require_once dirname(dirname(__FILE__)) . '/config.core.php';
+require_once MODX_CORE_PATH . 'model/modx/modx.class.php';
+
+$modx = new modX();
+$modx->initialize('web');
+$modx->getService('error', 'error.modError', '', '');
+
+$path = $modx->getOption(
+    'mypackage.core_path',
+    null,
+    $modx->getOption('core_path') . 'components/mypackage/'
+) . 'model/mypackage/';
 $modx->getService('mypackage', 'myPackage', $path);
-// Load the modRestService class and pass it some basic configuration
-$rest = $modx->getService('rest', 'rest.modRestService', '', array(
+
+$rest = $modx->getService('rest', 'rest.modRestService', '', [
     'basePath' => dirname(__FILE__) . '/Controllers/',
     'controllerClassSeparator' => '',
     'controllerClassPrefix' => 'MyController',
     'xmlRootNode' => 'response',
-));
-// Prepare the request
+]);
+
 $rest->prepare();
-// Make sure the user has the proper permissions, send the user a 401 error if not
 if (!$rest->checkPermissions()) {
     $rest->sendUnauthorized(true);
 }
-// Run the request
 $rest->process();
 ```
 
-With that in place, next you'll need to make sure the all requests to your `/rest/` folder are actually handled by the REST server. To do that, add the following to your `.htaccess` (or the equivalent on nginx or other systems) in the root of your site:
+`checkPermissions()` on the service returns `true` by default. Override it on a custom service subclass (or gate traffic earlier) when every request must pass a site-wide check. Per-controller auth uses `verifyAuthentication()` (see below).
 
-### Apache
+### URL rewriting
 
-``` plain
+Put rewrite rules **inside** `rest/` so the rest of the site keeps normal routing.
+
+**Apache** (`rest/.htaccess`):
+
+```apache
 RewriteEngine On
+RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
-RewriteCond %{REQUEST_FILENAME} !-s
-RewriteRule ^(.*)$ rest/index.php?_rest=$1 [QSA,NC,L]
-RewriteCond %{REQUEST_FILENAME} -d
-RewriteRule ^(.*)$ rest/index.php [QSA,NC,L]
+RewriteRule ^(.*)$ index.php?_rest=$1 [QSA,L]
 ```
 
-### NGINX
+**nginx**:
 
-``` plain
+```nginx
 location /rest/ {
     try_files $uri @modx_rest;
 }
@@ -75,76 +117,233 @@ location @modx_rest {
 }
 ```
 
-If you were to open /rest/foobar in your browser now, you should get an error that indicates your API is working, yay!
+Open `/rest/foobar` in a browser. A working bootstrap returns JSON like:
 
-``` json
+```json
 {
-    success: false,
-    message: "Method not allowed",
-    object: [ ],
-    code: 405
+    "success": false,
+    "message": "Method not allowed",
+    "object": [],
+    "code": 405
 }
 ```
 
-Now we can get started with the actual API building!
+That 405 means the router ran and found no matching controller. Next step: add controllers.
 
-## 2. Building API Endpoints
+### Useful `modRestService` options
 
-The actual API consists of a bunch of endpoints. If you want to build a proper RESTful API each endpoint would match a "resource" (not necessarily the kind from the left tree!), and the different HTTP verbs (GET, POST, PUT and DELETE) would be used to interact with specific objects. Say you're building an API for managing your to do list, you could have an endpoint "items" with the following actions:
+| Option | Default | Role |
+| --- | --- | --- |
+| `basePath` | site `base_path` | Directory of controller files |
+| `controllerClassPrefix` | `modRestController` | Prefix prepended to the class loaded from the file name |
+| `controllerClassSeparator` | `''` | Joiner between prefix and class segment |
+| `requestParameter` | `_rest` | Query param that carries the path (`items`, `items/15`) |
+| `defaultResponseFormat` | `json` | `json` or `xml` when no suffix is present |
+| `collectionResultsKey` / `collectionTotalKey` | `results` / `total` | Keys in list responses |
+| `propertyLimit` / `propertyOffset` | `limit` / `start` | Query param names for pagination |
+| `propertySort` / `propertySortDir` | `sort` / `dir` | Query param names for sorting |
+| `propertySearch` | `search` | Query param name for text search |
+| `defaultSuccessStatusCode` / `defaultFailureStatusCode` | `200` / `200` | HTTP status codes used by `success()` / `failure()` |
 
-- `GET /items`: returns items on your to do list
-- `GET /items/15`: returns the item with primary key 15
-- `POST /items`: create a new item on the to do list
-- `PUT /items/15`: update one or more values on your to do list item with primary key 15
-- `DELETE /items/15`: delete the item with primary key 15
+## 2. Building API endpoints
 
-There is a lot of discussion around the web about how to name your endpoints - in this case we went for the plural "items". One thing to note is that we don't have endpoints like /items/create - that is already covered by POSTing to /items and is a key aspect of building RESTful APIs.
+Map one path segment to one resource type. HTTP verbs do the work:
 
-To create your Items endpoint , you will need to create the Items controller. Based on the configuration we passed to the modRestService earlier, and the defaults, each controller needs to start with MyController, be placed in a `/rest/Controllers/` directory and the file must match the endpoint name suffixed with `.php`. So create a new file `/rest/Controllers/Items.php`. Give it the following contents:
+- `GET /items` — list
+- `GET /items/15` — read primary key `15`
+- `POST /items` — create
+- `PUT /items/15` — update
+- `DELETE /items/15` — delete
 
-``` php
-class MyControllerItems extends modRestController {
+Skip paths like `/items/create`. `POST /items` already means create.
+
+With `controllerClassPrefix => 'MyController'` and empty separator, file `rest/Controllers/Items.php` must define class `MyControllerItems`.
+
+### MODX 3.x controller
+
+```php
+<?php
+use MODX\Revolution\Rest\modRestController;
+
+class MyControllerItems extends modRestController
+{
     public $classKey = 'ToDoItem';
     public $defaultSortField = 'sortorder';
     public $defaultSortDirection = 'ASC';
 }
 ```
 
-Assuming ToDoItem is the name of a valid xPDOObject derivative, and you loaded it with $modx->addPackage() somewhere (for example in your Service class that we called in the index.php), you now have a fully functional RESTful API for your ToDoItem objects. Just request /rest/items and it should return your ToDoItems in pretty JSON.
+### MODX 2.x controller
 
-If you don't have a package ready, you can also set the classKey property to "modResource" and the defaultSortField to "id" to set up an API for all resources.
-
-``` json
+```php
+<?php
+class MyControllerItems extends modRestController
 {
-  results: [
-    {
-       id: 1,
-       sortorder: 1,
-       name: "Finish documenting RESTful APIs",
-       added: "2014-09-14",
-       target_completion_date: "2014-10-14",
-       assigned_to: ""
-    },
-    // ...
-  ],
-  total: 1
+    public $classKey = 'ToDoItem';
+    public $defaultSortField = 'sortorder';
+    public $defaultSortDirection = 'ASC';
 }
 ```
 
-It's like magic! But you know what's even better? It is a full blown API now... if you go back to the actions we mentioned earlier, they will all work out of the box. `/rest/items/1` will return only the to do item with ID 1, for example. To test the POST, PUT and DELETE, you will probably need to use something like [Postman](https://chrome.google.com/webstore/detail/postman-rest-client/fdmmgilgnpjigdojojpjoooidkmcomcm)[](https://chrome.google.com/webstore/detail/postman-rest-client/fdmmgilgnpjigdojojpjoooidkmcomcm) or curl to send the proper requests but they should be functional now too.
+Load the package with `addPackage()` (or your Extra's service) before `process()` so `ToDoItem` resolves. For a quick experiment without a custom package, set `$classKey = 'modResource'` (or `\MODX\Revolution\modResource` in 3.x) and `$defaultSortField = 'id'`.
 
-Now that you have your basic API running, it's time to start doing some real development and making it work the way you want it to.
+`GET /rest/items` then returns a collection:
 
-## 3. Making your Endpoints smarter
+```json
+{
+    "results": [
+        {
+            "id": 1,
+            "sortorder": 1,
+            "name": "Finish documenting RESTful APIs",
+            "added": "2014-09-14",
+            "target_completion_date": "2014-10-14",
+            "assigned_to": ""
+        }
+    ],
+    "total": 1
+}
+```
 
-The majority of the work following now boils down to making your endpoints smarter, and adding more of them. You will probably want to change the way your data is returned, filter out unwanted data and more like that. The modRestController has all the options and hooks for you to do just that.
+`GET /rest/items/1`, `POST`, `PUT`, and `DELETE` work from the same class. Use curl or an API client to send non-GET verbs.
 
-Each of the requests is passed to a specific method in your Controller. This means that when you, for example, request `GET /items`, which returns a list of objects, it is handled by the `modRestController.getList()` method. This is how requests are routed to the controller:
+### Request routing
 
-- GET /items: `modRestController.get()` which calls `modRestController.getList()`
-- GET /items/5: `modRestController.get()` which calls `modRestController.read()`
-- POST /items: `modRestController.post()`
-- PUT /items/5: `modRestController.put()`
-- DELETE /items/5: `modRestController.delete()`
+| Request | Controller entry |
+| --- | --- |
+| `GET /items` | `get()` → `getList()` |
+| `GET /items/5` | `get()` → `read($id)` |
+| `POST /items` | `post()` |
+| `PUT /items/5` | `put()` |
+| `DELETE /items/5` | `delete()` |
 
-These methods by default do what you would expect them to do with some sensible error handling and - for the most part - don't need to be customised. There are also methods such as `modRestController.beforePost()`, `modRestController.beforePut()`, `modRestController.beforeDelete()` that allow you to prevent the action (creating, updating or deleting an object respectively) by returning false. The object in question is available via `$this->object`, so you could make sure the user has permission to complete the action or otherwise prepare stuff. There is also `modRestController.afterRead()`, `modRestController.afterPost()`, `modRestController.afterPut()` and `modRestController.afterDelete()` for doing stuff after the action is completed. These methods get passed an array by reference which contains the object that is about to be returned.
+The ID segment is copied onto `$this->primaryKeyField` (default `id`) before the method runs.
+
+### List query parameters
+
+Defaults from the service config:
+
+| Param | Purpose |
+| --- | --- |
+| `limit` | Page size (controller `$defaultLimit`, default `20`) |
+| `start` | Offset |
+| `sort` | Field name (falls back to `$defaultSortField`) |
+| `dir` | `ASC` or `DESC` |
+| `search` | LIKE filter across `$searchFields` |
+
+Example: `/rest/items?limit=10&start=0&sort=name&dir=ASC&search=docs`
+
+## 3. Controller properties
+
+Set these on your controller class to drive the default CRUD path:
+
+| Property | Role |
+| --- | --- |
+| `$classKey` | xPDO class to load |
+| `$classAlias` | Optional query alias |
+| `$primaryKeyField` | Field used for read/update/delete (default `id`) |
+| `$defaultSortField` / `$defaultSortDirection` | Default list sorting |
+| `$defaultLimit` / `$defaultOffset` | Default pagination |
+| `$searchFields` | Fields searched when `search` is present |
+| `$postRequiredFields` / `$putRequiredFields` / `$deleteRequiredFields` | Required request fields |
+| `$postRequiredRelatedObjects` / `$putRequiredRelatedObjects` | Map of `field => classKey` that must exist |
+| `$postMethod` / `$putMethod` / `$deleteMethod` | Object methods called to persist (`save` / `save` / `remove`) |
+| `$allowedMethods` | HTTP verbs this controller accepts |
+
+## 4. Hooks and response shaping
+
+Default `get` / `post` / `put` / `delete` already handle the happy path. Override hooks when you need filters, permissions, or a different payload.
+
+**Before write/delete** — return `true` to continue, or `false` / an error string to abort:
+
+- `beforePost()`
+- `beforePut()`
+- `beforeDelete()`
+
+The object sits on `$this->object`.
+
+**After read/write** — `afterRead`, `afterPost`, `afterPut`, and `afterDelete` receive the outgoing array by reference. Change fields there before the response leaves.
+
+**List customisation:**
+
+- `prepareListQueryBeforeCount(xPDOQuery $c)` / `prepareListQueryAfterCount(xPDOQuery $c)` — add joins or `where` clauses
+- `prepareListObject(xPDOObject $object)` — map each row (default `toArray()`)
+- `addSearchQuery()` — override search behaviour
+
+**Helpers you call from overrides:**
+
+- `$this->getProperty($key)` / `setProperty()` / `getProperties()`
+- `$this->success($message, $object, $status)`
+- `$this->failure($message, $object, $status)`
+- `$this->collection($list, $total, $status)`
+- `$this->addFieldError($field, $message)`
+
+Example: expose only a subset of fields on list responses:
+
+```php
+protected function prepareListObject(xPDOObject $object)
+{
+    $row = $object->toArray();
+    return [
+        'id' => $row['id'],
+        'name' => $row['name'],
+        'sortorder' => $row['sortorder'],
+    ];
+}
+```
+
+Example: block creates unless a field is present:
+
+```php
+public $postRequiredFields = ['name'];
+
+public function beforePost()
+{
+    if ($this->getProperty('name') === 'blocked') {
+        return 'That name is not allowed';
+    }
+    return parent::beforePost();
+}
+```
+
+## 5. Authentication and protection
+
+Each controller has `protected $protected = true` by default. When protected, `process()` calls `verifyAuthentication()` before the verb method (except `OPTIONS`). The stock `verifyAuthentication()` returns `true`.
+
+For a public endpoint, set:
+
+```php
+protected $protected = false;
+```
+
+For a real check, keep `$protected = true` and override:
+
+```php
+public function verifyAuthentication()
+{
+    $key = $this->getProperty('api_key');
+    return $key && $key === $this->modx->getOption('mypackage.api_key');
+}
+```
+
+Failed auth becomes HTTP 401 with the standard error payload. Pair this with HTTPS and your own token or session scheme. The core does not ship OAuth for this stack.
+
+`modRestService::checkPermissions()` is a separate gate that runs in your bootstrap when you call it. Override that method on a custom service class for global rules.
+
+## 6. Response format
+
+JSON is the default. Request XML with a `.xml` suffix when the format is enabled (`/rest/items.xml`), or set `defaultResponseFormat` to `xml`.
+
+Success and failure bodies use keys from the service config (`success`, `message`, `object`, plus `errors` when field errors exist). List calls use `results` and `total`.
+
+Default HTTP status for both success and failure is `200`. Pass a third argument to `success()` / `failure()`, or change `defaultSuccessStatusCode` / `defaultFailureStatusCode`, when you need 201/404-style codes.
+
+## 7. Nested controllers
+
+Controllers may live in subfolders under `basePath`. The class name still uses the configured prefix and separator. With an empty separator, `Controllers/Users/Profile.php` maps to a class like `MyControllerUsersProfile` and path `/rest/users/profile`.
+
+## See also
+
+- [HTTP Client](extending-modx/services/http) — outbound requests from MODX 3
+- [modRest](extending-modx/services/modrest) — deprecated outbound client
+- [xPDO retrieving objects](extending-modx/xpdo/retrieving-objects) — query patterns you reuse in `prepareListQuery*`

--- a/ru/extending-modx/developing-restful-api.md
+++ b/ru/extending-modx/developing-restful-api.md
@@ -7,7 +7,7 @@ MODX даёт небольшой REST-сервер на классах `modRestS
 
 Страница покрывает MODX 2.3+ и MODX 3.x. В 3.x классы лежат в `MODX\Revolution\Rest\*`. Поведение сервиса и контроллеров совпадает с примерами ниже.
 
-> Исходящие HTTP-запросы из MODX к чужим API — другой стек. См. [HTTP-клиент](extending-modx/services/http). Устаревший клиент `modRest` описан в [Services](extending-modx/services/modrest).
+> Исходящие HTTP-запросы из MODX к чужим API это другой стек. См. [HTTP-клиент](extending-modx/services/http). Устаревший клиент `modRest` описан в [Services](extending-modx/services/modrest).
 
 ## Что почитать заранее
 
@@ -146,13 +146,13 @@ location @modx_rest {
 
 ## 2. Конечные точки API
 
-Один сегмент пути — один тип ресурса. HTTP-глаголы делают работу:
+Один сегмент пути это один тип ресурса. HTTP-глаголы делают работу:
 
-- `GET /items` — список
-- `GET /items/15` — чтение по первичному ключу `15`
-- `POST /items` — создание
-- `PUT /items/15` — обновление
-- `DELETE /items/15` — удаление
+- `GET /items`: список
+- `GET /items/15`: чтение по первичному ключу `15`
+- `POST /items`: создание
+- `PUT /items/15`: обновление
+- `DELETE /items/15`: удаление
 
 Пути вроде `/items/create` не нужны. `POST /items` уже означает создание.
 
@@ -253,7 +253,7 @@ class MyControllerItems extends modRestController
 
 Стандартные `get` / `post` / `put` / `delete` закрывают обычный сценарий. Хуки нужны для фильтров, прав и другого payload.
 
-**До записи/удаления** — верните `true`, чтобы продолжить, или `false` / строку ошибки, чтобы остановить:
+**До записи/удаления**: верните `true`, чтобы продолжить, или `false` / строку ошибки, чтобы остановить:
 
 - `beforePost()`
 - `beforePut()`
@@ -261,13 +261,13 @@ class MyControllerItems extends modRestController
 
 Объект доступен как `$this->object`.
 
-**После чтения/записи** — `afterRead`, `afterPost`, `afterPut` и `afterDelete` получают исходящий массив по ссылке. Меняйте поля там.
+**После чтения/записи**: `afterRead`, `afterPost`, `afterPut` и `afterDelete` получают исходящий массив по ссылке. Меняйте поля там.
 
 **Список:**
 
-- `prepareListQueryBeforeCount(xPDOQuery $c)` / `prepareListQueryAfterCount(xPDOQuery $c)` — join и `where`
-- `prepareListObject(xPDOObject $object)` — разметка строки (по умолчанию `toArray()`)
-- `addSearchQuery()` — своя логика поиска
+- `prepareListQueryBeforeCount(xPDOQuery $c)` / `prepareListQueryAfterCount(xPDOQuery $c)`: join и `where`
+- `prepareListObject(xPDOObject $object)`: разметка строки (по умолчанию `toArray()`)
+- `addSearchQuery()`: своя логика поиска
 
 **Хелперы:**
 
@@ -315,7 +315,7 @@ public function beforePost()
 protected $protected = false;
 ```
 
-Своя проверка — оставьте `$protected = true` и переопределите:
+Своя проверка: оставьте `$protected = true` и переопределите:
 
 ```php
 public function verifyAuthentication()
@@ -327,7 +327,7 @@ public function verifyAuthentication()
 
 Ошибка авторизации даёт HTTP 401 и стандартный error payload. Держите HTTPS и свою схему токена или сессии. OAuth в этом стеке ядро не поставляет.
 
-`modRestService::checkPermissions()` — отдельный барьер в bootstrap. Для глобальных правил переопределите метод в своём классе сервиса.
+`modRestService::checkPermissions()` это отдельный барьер в bootstrap. Для глобальных правил переопределите метод в своём классе сервиса.
 
 ## 6. Формат ответа
 
@@ -335,7 +335,7 @@ public function verifyAuthentication()
 
 Тела success/failure используют ключи из конфига сервиса (`success`, `message`, `object`, плюс `errors` при ошибках полей). Списки используют `results` и `total`.
 
-HTTP-статус по умолчанию для успеха и ошибки — `200`. Передайте третий аргумент в `success()` / `failure()` или смените `defaultSuccessStatusCode` / `defaultFailureStatusCode`, если нужны коды вроде 201 или 404.
+HTTP-статус по умолчанию для успеха и ошибки: `200`. Передайте третий аргумент в `success()` / `failure()` или смените `defaultSuccessStatusCode` / `defaultFailureStatusCode`, если нужны коды вроде 201 или 404.
 
 ## 7. Вложенные контроллеры
 
@@ -343,6 +343,6 @@ HTTP-статус по умолчанию для успеха и ошибки �
 
 ## Смотрите также
 
-- [HTTP-клиент](extending-modx/services/http) — исходящие запросы в MODX 3
-- [modRest](extending-modx/services/modrest) — устаревший исходящий клиент
-- [Выборка объектов xPDO](extending-modx/xpdo/retrieving-objects) — запросы, которые вы переиспользуете в `prepareListQuery*`
+- [HTTP-клиент](extending-modx/services/http): исходящие запросы в MODX 3
+- [modRest](extending-modx/services/modrest): устаревший исходящий клиент
+- [Выборка объектов xPDO](extending-modx/xpdo/retrieving-objects): запросы, которые вы переиспользуете в `prepareListQuery*`

--- a/ru/extending-modx/developing-restful-api.md
+++ b/ru/extending-modx/developing-restful-api.md
@@ -3,147 +3,346 @@ title: "Разработка RESTful API"
 translation: "extending-modx/developing-restful-api"
 ---
 
-В MODX 2.3 появился удобный метод разработки API-интерфейсов RESTful поверх MODX. Это делается с помощью класса modRestService и производных modRestController. Он поддерживает множество интересных функций для взаимодействия с экземплярами xPDOObject. Цель этого документа - предоставить вам информацию, необходимую для создания собственного API.
+MODX даёт небольшой REST-сервер на классах `modRestService` и `modRestController`. Вы направляете HTTP-запросы на bootstrap-скрипт, сопоставляете пути URL с классами контроллеров и получаете CRUD над объектами xPDO плюс хуки для авторизации, валидации и формы ответа.
 
-## Рекомендуемое предварительное чтение
+Страница покрывает MODX 2.3+ и MODX 3.x. В 3.x классы лежат в `MODX\Revolution\Rest\*`. Поведение сервиса и контроллеров совпадает с примерами ниже.
 
-Перед созданием RESTful API полезно знать, что такое RESTful API и как это должно работать. В Интернете доступно множество ресурсов, и "[Разработка API, который вы не будете ненавидеть](https://leanpub.com/build-apis-you-wont-hate)" автора Phil Sturgeon - это отличная (электронная) книга, которую полезно почитать.
+> Исходящие HTTP-запросы из MODX к чужим API — другой стек. См. [HTTP-клиент](extending-modx/services/http). Устаревший клиент `modRest` описан в [Services](extending-modx/services/modrest).
 
-## В двух словах
+## Что почитать заранее
 
-1. Создайте файл `index.php`, который обрабатывает загрузку MODX, настраивает службу REST с правильной конфигурацией и передает запрос контроллеру (см. п.3).
-2. Создайте файл `.htaccess`, который направляет все запросы (в поддиректории или в определенном домене) в  `index.php`  из п.1.
-3. Создайте контроллеры для каждой из ваших конечных точек
+Книга Phil Sturgeon *[Build APIs you won't hate](https://leanpub.com/build-apis-you-wont-hate)* хорошо закрывает REST-соглашения до того, как вы начнёте писать контроллеры.
+
+## Коротко
+
+1. Создайте `rest/index.php`: загрузка MODX, настройка `modRestService`, вызовы `prepare()` и `process()`.
+2. Направьте `/rest/*` на этот скрипт (`.htaccess` внутри `rest/` или `location` в nginx).
+3. Добавьте по одному классу контроллера на конечную точку в `rest/Controllers/`.
 
 ## 1. Начальная загрузка API
 
-Классы `modRestService` и `modRestController` значительно облегчат вашу работу, но вам нужно настроить некоторый базовый код для его подключения. Для этого документа мы предполагаем, что вы помещаете свой API в папку `/rest/`, при необходимости корректируйте пути.
+Кладите API в `/rest/` (пути поправьте под свой каталог).
 
-Сначала создайте файл `rest/index.php`, который выглядит примерно так:
+### MODX 3.x
 
 ```php
 <?php
-// Загрузить MODX
-require_once dirname(dirname(__FILE__)) . '/config.core.php';
-require_once MODX_CORE_PATH . 'model/modx/modx.class.php';
+use MODX\Revolution\modX;
+use MODX\Revolution\Rest\modRestService;
+
+require_once dirname(__DIR__) . '/config.core.php';
+require_once MODX_CORE_PATH . 'vendor/autoload.php';
+
 $modx = new modX();
 $modx->initialize('web');
-$modx->getService('error','error.modError', '', '');
-// Загрузить любые классы или пакеты (модели), которые вам потребуются
-$path = $modx->getOption('mypackage.core_path', null,
-  $modx->getOption('core_path').'components/mypackage/') . 'model/mypackage/';
-$modx->getService('mypackage', 'myPackage', $path);
-// Загрузить класс modRestService и передать ему некоторую базовую конфигурацию
-$rest = $modx->getService('rest', 'rest.modRestService', '', array(
-   'basePath' => dirname(__FILE__) . '/Controllers/',
-   'controllerClassSeparator' => '',
-   'controllerClassPrefix' => 'MyController',
-   'xmlRootNode' => 'response',
-));
-// Подготовить запрос
+$modx->getService('error', 'error.modError', '', '');
+
+$path = $modx->getOption(
+    'mypackage.core_path',
+    null,
+    $modx->getOption('core_path') . 'components/mypackage/'
+) . 'model/mypackage/';
+$modx->addPackage('mypackage', $path);
+
+$rest = new modRestService($modx, [
+    'basePath' => __DIR__ . '/Controllers/',
+    'controllerClassSeparator' => '',
+    'controllerClassPrefix' => 'MyController',
+    'xmlRootNode' => 'response',
+]);
+
 $rest->prepare();
-// Удостовериться, что пользователю предоставлены необходимые права доступа; вернуть пользователю ошибку 401 в обратном случае
 if (!$rest->checkPermissions()) {
-   $rest->sendUnauthorized(true);
+    $rest->sendUnauthorized(true);
 }
-// Выполнить запрос
 $rest->process();
 ```
 
-После этого вам необходимо убедиться, что все запросы к вашей папке `/rest/` действительно обрабатываются сервером REST. Чтобы сделать это, добавьте следующее в ваш`.htaccess` (или эквивалент в nginx или других системах) в корне вашего сайта:
-
-### Apache
-
-```plain
-RewriteEngine On
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteCond %{REQUEST_FILENAME} !-s
-RewriteRule ^(.*)$ rest/index.php?_rest=$1 [QSA,NC,L]
-RewriteCond %{REQUEST_FILENAME} -d
-RewriteRule ^(.*)$ rest/index.php [QSA,NC,L]
-```
-
-### NGINX
-
-```plain
-location /rest/ {
-   try_files $uri @modx_rest;
-}
-location @modx_rest {
-   rewrite ^/rest/(.*)$ /rest/index.php?_rest=$1&$args last;
-}
-```
-
-Если вы сейчас откроете /rest/foobar в вашем браузере, вы должны получить ошибку, которая указывает на то, что ваш API работает, ура!
-
-```json
-{
- success: false,
- message: "Method not allowed",
- object: [ ],
- code: 405
-}
-```
-
-Теперь мы можем начать с фактической разработки API!
-
-## 2. Построение конечных точек API
-
-Настоящий API состоит из нескольких конечных точек. Если вы хотите создать правильный RESTful API, каждая конечная точка будет соответствовать «ресурсу» (не обязательно виду из левого древа MODX!), И различные HTTP-глаголы (GET, POST, PUT и DELETE) будут использоваться для взаимодействия с конкретными объектами. Допустим, вы создаете API для управления списком дел, у вас могут быть «элементы» конечной точки со следующими действиями:
-
-- `GET /items`: возвращает элементы в вашем списке дел
-- `GET /items/15`: возвращает элемент с первичным ключом 15
-- `POST /items`: создать новый элемент в списке дел
-- `PUT /items/15`: обновить одно или несколько значений в вашем списке дел с помощью первичного ключа 15
-- `DELETE /items/15`: удалить элемент с помощью первичного ключа 15
-
-В интернете много спорят о том, как назвать ваши конечные точки - в данном случае мы выбрали множественные «пункты». Стоит отметить, что у нас нет конечных точек, таких как /items/create, - это уже покрыто POST для /items и является ключевым аспектом построения API RESTful.
-
-Чтобы создать конечную точку элементов (items), вам необходимо создать контроллер элементов (items controller). Исходя из конфигурации, которую мы передали в modRestService ранее, и значений по умолчанию, каждый контроллер должен начинаться с MyController, помещаться в каталог `/rest/Controllers/`, а файл должен соответствовать имени конечной точки с суффиксом `.php`. Поэтому создайте новый файл `/rest/Controllers/Items.php` и скопируйте в него следующий код:
+### MODX 2.x
 
 ```php
-class MyControllerItems extends modRestController {
-   public $classKey = 'ToDoItem';
-   public $defaultSortField = 'sortorder';
-   public $defaultSortDirection = 'ASC';
+<?php
+require_once dirname(dirname(__FILE__)) . '/config.core.php';
+require_once MODX_CORE_PATH . 'model/modx/modx.class.php';
+
+$modx = new modX();
+$modx->initialize('web');
+$modx->getService('error', 'error.modError', '', '');
+
+$path = $modx->getOption(
+    'mypackage.core_path',
+    null,
+    $modx->getOption('core_path') . 'components/mypackage/'
+) . 'model/mypackage/';
+$modx->getService('mypackage', 'myPackage', $path);
+
+$rest = $modx->getService('rest', 'rest.modRestService', '', [
+    'basePath' => dirname(__FILE__) . '/Controllers/',
+    'controllerClassSeparator' => '',
+    'controllerClassPrefix' => 'MyController',
+    'xmlRootNode' => 'response',
+]);
+
+$rest->prepare();
+if (!$rest->checkPermissions()) {
+    $rest->sendUnauthorized(true);
+}
+$rest->process();
+```
+
+`checkPermissions()` у сервиса по умолчанию возвращает `true`. Переопределите метод в своём подклассе сервиса (или режьте трафик раньше), если нужна проверка на каждый запрос. Авторизация на уровне контроллера идёт через `verifyAuthentication()` (ниже).
+
+### Перезапись URL
+
+Правила rewrite кладите **внутрь** `rest/`, чтобы остальной сайт ходил как обычно.
+
+**Apache** (`rest/.htaccess`):
+
+```apache
+RewriteEngine On
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^(.*)$ index.php?_rest=$1 [QSA,L]
+```
+
+**nginx**:
+
+```nginx
+location /rest/ {
+    try_files $uri @modx_rest;
+}
+location @modx_rest {
+    rewrite ^/rest/(.*)$ /rest/index.php?_rest=$1&$args last;
 }
 ```
 
-Предполагая, что ToDoItem является именем допустимого производного xPDOObject, и вы загрузили его где-то с помощью $modx->addPackage() (например, в свой класс Service, который мы вызвали в index.php), теперь у вас есть полностью функциональный RESTful API для ваших объектов ToDoItem. Просто запросите /rest/items, и данный вызов должен вернуть ваши ToDoItems в симпатичном формате JSON.
-
-Если у вас нет готового пакета, вы также можете установить для свойства classKey значение «modResource» и для defaultSortField значение «id», чтобы настроить API для всех ресурсов.
+Откройте `/rest/foobar` в браузере. Рабочий bootstrap отдаёт JSON вида:
 
 ```json
 {
- results: [
-   {
-      id: 1,
-      sortorder: 1,
-      name: "Заканчиваем документировать RESTful API",
-      added: "2014-09-14",
-      target_completion_date: "2014-10-14",
-      assigned_to: ""
-   },
-   // ...
- ],
- total: 1
+    "success": false,
+    "message": "Method not allowed",
+    "object": [],
+    "code": 405
 }
 ```
 
-Это как волшебство! Но вы знаете, что еще лучше? Это полноценный API сейчас... И если вы вернетесь к действиям, которые мы упоминали ранее, все они будут работать "из коробки". Например, `/rest/items/1`, вернет только элемент to do с идентификатором 1. Чтобы проверить POST, PUT и DELETE, вам, вероятно, потребуется использовать что-то вроде [Postman](https://chrome.google.com/webstore/detail/postman-rest-client/fdmmgilgnpjigdojojpjoooidkmcomcm) или curl для отправки правильных запросов, но теперь они также должны быть функциональными.
+Код 405 значит: роутер отработал, контроллер не найден. Дальше добавляйте контроллеры.
 
-Теперь, когда у вас работает базовый API, пришло время приступить к реальной разработке и заставить ее работать так, как вы хотите.
+### Полезные опции `modRestService`
 
-## 3. Делая ваши конечные точки умнее
+| Опция | По умолчанию | Назначение |
+| --- | --- | --- |
+| `basePath` | `base_path` сайта | Каталог файлов контроллеров |
+| `controllerClassPrefix` | `modRestController` | Префикс класса из имени файла |
+| `controllerClassSeparator` | `''` | Соединитель префикса и сегмента класса |
+| `requestParameter` | `_rest` | GET-параметр с путём (`items`, `items/15`) |
+| `defaultResponseFormat` | `json` | `json` или `xml`, если суффикса нет |
+| `collectionResultsKey` / `collectionTotalKey` | `results` / `total` | Ключи в ответе списка |
+| `propertyLimit` / `propertyOffset` | `limit` / `start` | Имена параметров пагинации |
+| `propertySort` / `propertySortDir` | `sort` / `dir` | Имена параметров сортировки |
+| `propertySearch` | `search` | Имя параметра текстового поиска |
+| `defaultSuccessStatusCode` / `defaultFailureStatusCode` | `200` / `200` | HTTP-коды для `success()` / `failure()` |
 
-Большая часть следующей работы сводится к тому, чтобы сделать ваши конечные точки более умными и добавить их больше. Возможно, вы захотите изменить способ возврата ваших данных, отфильтровать ненужные данные и многое другое. У ModRestController есть все опции и хуки для вас, чтобы сделать это.
+## 2. Конечные точки API
 
-Каждый из запросов передается определенному методу в вашем контроллере. Это означает, что когда вы, например, запрашиваете `GET /items`, который возвращает список объектов, он обрабатывается методом `modRestController.getList()`. Вот как запросы направляются на контроллер:
+Один сегмент пути — один тип ресурса. HTTP-глаголы делают работу:
 
-- GET /items: `modRestController.get()`, который вызывает `modRestController.getList()`
-- GET /items/5: `modRestController.get()`, который вызывает `modRestController.read()`
-- POST /items: `modRestController.post()`
-- PUT /items/5: `modRestController.put()`
-- DELETE /items/5: `modRestController.delete()`
+- `GET /items` — список
+- `GET /items/15` — чтение по первичному ключу `15`
+- `POST /items` — создание
+- `PUT /items/15` — обновление
+- `DELETE /items/15` — удаление
 
-Эти методы по умолчанию делают то, что вы ожидаете от них, с некоторой разумной обработкой ошибок и - по большей части - не нуждаются в настройке. Существуют также такие методы, как `modRestController.beforePost()`, `modRestController.beforePut()`, `modRestController.beforeDelete()`, которые позволяют предотвратить действие (создание, обновление или удаление объекта соответственно) путем возврата false. Обсуждаемый объект доступен через `$this->object`, так что вы можете убедиться, что у пользователя есть разрешение на выполнение действия или другую подготовку. Существует также `modRestController.afterRead()`, `modRestController.afterPost()`, `modRestController.afterPut()` и `modRestController.afterDelete()` для выполнения действий после завершения действия. Этим методам передается массив по ссылке, который содержит объект, который должен быть возвращен.
+Пути вроде `/items/create` не нужны. `POST /items` уже означает создание.
+
+При `controllerClassPrefix => 'MyController'` и пустом separator файл `rest/Controllers/Items.php` должен объявлять класс `MyControllerItems`.
+
+### Контроллер для MODX 3.x
+
+```php
+<?php
+use MODX\Revolution\Rest\modRestController;
+
+class MyControllerItems extends modRestController
+{
+    public $classKey = 'ToDoItem';
+    public $defaultSortField = 'sortorder';
+    public $defaultSortDirection = 'ASC';
+}
+```
+
+### Контроллер для MODX 2.x
+
+```php
+<?php
+class MyControllerItems extends modRestController
+{
+    public $classKey = 'ToDoItem';
+    public $defaultSortField = 'sortorder';
+    public $defaultSortDirection = 'ASC';
+}
+```
+
+Загрузите пакет через `addPackage()` (или сервис Extra) до `process()`, чтобы `ToDoItem` находился. Для быстрого теста без своего пакета поставьте `$classKey = 'modResource'` (в 3.x можно `\MODX\Revolution\modResource`) и `$defaultSortField = 'id'`.
+
+`GET /rest/items` вернёт коллекцию:
+
+```json
+{
+    "results": [
+        {
+            "id": 1,
+            "sortorder": 1,
+            "name": "Закончить документацию RESTful API",
+            "added": "2014-09-14",
+            "target_completion_date": "2014-10-14",
+            "assigned_to": ""
+        }
+    ],
+    "total": 1
+}
+```
+
+`GET /rest/items/1`, `POST`, `PUT` и `DELETE` работают из того же класса. Для глаголов кроме GET удобны curl или API-клиент.
+
+### Маршрутизация запросов
+
+| Запрос | Вход в контроллер |
+| --- | --- |
+| `GET /items` | `get()` → `getList()` |
+| `GET /items/5` | `get()` → `read($id)` |
+| `POST /items` | `post()` |
+| `PUT /items/5` | `put()` |
+| `DELETE /items/5` | `delete()` |
+
+Сегмент ID копируется в `$this->primaryKeyField` (по умолчанию `id`) до вызова метода.
+
+### Параметры списка
+
+Значения по умолчанию из конфига сервиса:
+
+| Параметр | Назначение |
+| --- | --- |
+| `limit` | Размер страницы (`$defaultLimit` контроллера, обычно `20`) |
+| `start` | Смещение |
+| `sort` | Поле сортировки (иначе `$defaultSortField`) |
+| `dir` | `ASC` или `DESC` |
+| `search` | LIKE по полям из `$searchFields` |
+
+Пример: `/rest/items?limit=10&start=0&sort=name&dir=ASC&search=docs`
+
+## 3. Свойства контроллера
+
+Эти свойства задают поведение стандартного CRUD:
+
+| Свойство | Назначение |
+| --- | --- |
+| `$classKey` | Класс xPDO |
+| `$classAlias` | Необязательный alias в запросе |
+| `$primaryKeyField` | Поле для read/update/delete (по умолчанию `id`) |
+| `$defaultSortField` / `$defaultSortDirection` | Сортировка списка по умолчанию |
+| `$defaultLimit` / `$defaultOffset` | Пагинация по умолчанию |
+| `$searchFields` | Поля для параметра `search` |
+| `$postRequiredFields` / `$putRequiredFields` / `$deleteRequiredFields` | Обязательные поля запроса |
+| `$postRequiredRelatedObjects` / `$putRequiredRelatedObjects` | Карта `field => classKey`, объекты должны существовать |
+| `$postMethod` / `$putMethod` / `$deleteMethod` | Методы объекта для записи (`save` / `save` / `remove`) |
+| `$allowedMethods` | Допустимые HTTP-глаголы |
+
+## 4. Хуки и форма ответа
+
+Стандартные `get` / `post` / `put` / `delete` закрывают обычный сценарий. Хуки нужны для фильтров, прав и другого payload.
+
+**До записи/удаления** — верните `true`, чтобы продолжить, или `false` / строку ошибки, чтобы остановить:
+
+- `beforePost()`
+- `beforePut()`
+- `beforeDelete()`
+
+Объект доступен как `$this->object`.
+
+**После чтения/записи** — `afterRead`, `afterPost`, `afterPut` и `afterDelete` получают исходящий массив по ссылке. Меняйте поля там.
+
+**Список:**
+
+- `prepareListQueryBeforeCount(xPDOQuery $c)` / `prepareListQueryAfterCount(xPDOQuery $c)` — join и `where`
+- `prepareListObject(xPDOObject $object)` — разметка строки (по умолчанию `toArray()`)
+- `addSearchQuery()` — своя логика поиска
+
+**Хелперы:**
+
+- `$this->getProperty($key)` / `setProperty()` / `getProperties()`
+- `$this->success($message, $object, $status)`
+- `$this->failure($message, $object, $status)`
+- `$this->collection($list, $total, $status)`
+- `$this->addFieldError($field, $message)`
+
+Пример: в списке отдавать только часть полей:
+
+```php
+protected function prepareListObject(xPDOObject $object)
+{
+    $row = $object->toArray();
+    return [
+        'id' => $row['id'],
+        'name' => $row['name'],
+        'sortorder' => $row['sortorder'],
+    ];
+}
+```
+
+Пример: запретить создание при определённом имени:
+
+```php
+public $postRequiredFields = ['name'];
+
+public function beforePost()
+{
+    if ($this->getProperty('name') === 'blocked') {
+        return 'Такое имя нельзя';
+    }
+    return parent::beforePost();
+}
+```
+
+## 5. Авторизация и защита
+
+У контроллера по умолчанию `protected $protected = true`. При защите `process()` вызывает `verifyAuthentication()` до метода глагола (кроме `OPTIONS`). Штатный `verifyAuthentication()` возвращает `true`.
+
+Публичная точка:
+
+```php
+protected $protected = false;
+```
+
+Своя проверка — оставьте `$protected = true` и переопределите:
+
+```php
+public function verifyAuthentication()
+{
+    $key = $this->getProperty('api_key');
+    return $key && $key === $this->modx->getOption('mypackage.api_key');
+}
+```
+
+Ошибка авторизации даёт HTTP 401 и стандартный error payload. Держите HTTPS и свою схему токена или сессии. OAuth в этом стеке ядро не поставляет.
+
+`modRestService::checkPermissions()` — отдельный барьер в bootstrap. Для глобальных правил переопределите метод в своём классе сервиса.
+
+## 6. Формат ответа
+
+По умолчанию JSON. XML запрашивайте суффиксом `.xml` (`/rest/items.xml`) или через `defaultResponseFormat => 'xml'`.
+
+Тела success/failure используют ключи из конфига сервиса (`success`, `message`, `object`, плюс `errors` при ошибках полей). Списки используют `results` и `total`.
+
+HTTP-статус по умолчанию для успеха и ошибки — `200`. Передайте третий аргумент в `success()` / `failure()` или смените `defaultSuccessStatusCode` / `defaultFailureStatusCode`, если нужны коды вроде 201 или 404.
+
+## 7. Вложенные контроллеры
+
+Контроллеры могут лежать в подкаталогах `basePath`. Имя класса по-прежнему собирается из префикса и separator. При пустом separator файл `Controllers/Users/Profile.php` даёт класс вроде `MyControllerUsersProfile` и путь `/rest/users/profile`.
+
+## Смотрите также
+
+- [HTTP-клиент](extending-modx/services/http) — исходящие запросы в MODX 3
+- [modRest](extending-modx/services/modrest) — устаревший исходящий клиент
+- [Выборка объектов xPDO](extending-modx/xpdo/retrieving-objects) — запросы, которые вы переиспользуете в `prepareListQuery*`


### PR DESCRIPTION
## Description

Expands [Developing RESTful APIs](https://docs.modx.com/3.x/en/extending-modx/developing-restful-api) so the page covers a full working path: bootstrap for MODX 2.x and 3.x, rewrite rules inside `/rest/`, service options, controller properties, request routing, list query params, hooks, authentication (`$protected` / `verifyAuthentication`), and response formats.

Examples match `MODX\Revolution\Rest\modRestService` and `modRestController` on Revolution 3.x. The Russian translation is updated in parallel.

## Affected versions

3.x docs branch. Content covers 2.3+ and 3.x APIs. A 2.x docs cherry-pick may still help readers on that branch.

## Relevant issues

Fixes #101