### PR TITLE
docs(modext): Document MODx.util.Format.dateFromTimestamp

### DIFF
--- a/en/extending-modx/custom-manager-pages/modext.md
+++ b/en/extending-modx/custom-manager-pages/modext.md
@@ -31,6 +31,8 @@ There are a few components that are used throughout the MODx Manager, and will l
 8. [MODx.msg](extending-modx/custom-manager-pages/modext/modx.msg)
 9. [MODx.tree.Tree](extending-modx/custom-manager-pages/modext/modx.tree.tree)
 10. [MODx.Window](extending-modx/custom-manager-pages/modext/modx.window)
+11. [MODx.util.getHeaderBreadCrumbs](extending-modx/custom-manager-pages/modext/page_breadcrumbs)
+12. [MODx.util.Format.dateFromTimestamp](extending-modx/custom-manager-pages/modext/modx.util.format.datefromtimestamp) (3.x)
 
 ### More MODExt Components
 

--- a/en/extending-modx/custom-manager-pages/modext/modx.util.format.datefromtimestamp.md
+++ b/en/extending-modx/custom-manager-pages/modext/modx.util.format.datefromtimestamp.md
@@ -1,0 +1,46 @@
+---
+title: "MODx.util.Format.dateFromTimestamp"
+---
+
+## MODx.util.Format.dateFromTimestamp
+
+Available in MODX **3.x**. Turns a Unix timestamp into a string that follows the manager date and time formats from System Settings (`manager_date_format`, `manager_time_format`).
+
+Use it in CMP grids and panels when you show file times or other Unix timestamps and want the same look as the core manager UI.
+
+Defined in `manager/assets/modext/util/utilities.js` under `MODx.util.Format`.
+
+## Parameters
+
+| Name | Description | Default |
+| ---- | ----------- | ------- |
+| timestamp | Unix time. Ten-digit values are treated as seconds and converted to milliseconds. Values that are not greater than zero return `defaultValue`. | |
+| date | When `true`, appends `MODx.config.manager_date_format`. | `true` |
+| time | When `true`, appends `MODx.config.manager_time_format`. | `true` |
+| defaultValue | Returned for invalid timestamps, or when both `date` and `time` are false. | `''` |
+
+## Returns
+
+A formatted date/time string from Ext's `Date.format`, or `defaultValue`.
+
+Date and time parts join with a single space when both flags are true.
+
+## Examples
+
+Both date and time with manager formats:
+
+```javascript
+MODx.util.Format.dateFromTimestamp(1704067200);
+```
+
+Date only:
+
+```javascript
+MODx.util.Format.dateFromTimestamp(record.data.lastmod, true, false);
+```
+
+Fallback when the value is missing:
+
+```javascript
+MODx.util.Format.dateFromTimestamp(0, true, true, _('none'));
+```

--- a/ru/extending-modx/custom-manager-pages/modext.md
+++ b/ru/extending-modx/custom-manager-pages/modext.md
@@ -30,6 +30,8 @@ MODExt является расширением [JavaScript-фреймворка 
 8. [MODx.msg](extending-modx/custom-manager-pages/modext/modx.msg)
 9. [MODx.tree.Tree](extending-modx/custom-manager-pages/modext/modx.tree.tree)
 10. [MODx.Window](extending-modx/custom-manager-pages/modext/modx.window)
+11. [MODx.util.getHeaderBreadCrumbs](extending-modx/custom-manager-pages/modext/page_breadcrumbs)
+12. [MODx.util.Format.dateFromTimestamp](extending-modx/custom-manager-pages/modext/modx.util.format.datefromtimestamp) (3.x)
 
 ### Больше компонентов MODExt
 

--- a/ru/extending-modx/custom-manager-pages/modext/modx.util.format.datefromtimestamp.md
+++ b/ru/extending-modx/custom-manager-pages/modext/modx.util.format.datefromtimestamp.md
@@ -1,0 +1,47 @@
+---
+title: "MODx.util.Format.dateFromTimestamp"
+translation: "extending-modx/custom-manager-pages/modext/modx.util.format.datefromtimestamp"
+---
+
+## MODx.util.Format.dateFromTimestamp
+
+Доступен в MODX **3.x**. Превращает Unix-время в строку по форматам даты и времени менеджера из системных настроек (`manager_date_format`, `manager_time_format`).
+
+Вызывайте в сетках и панелях CMP, когда показываете время файлов или другие Unix-метки и хотите тот же вид, что в ядре менеджера.
+
+Определён в `manager/assets/modext/util/utilities.js` в объекте `MODx.util.Format`.
+
+## Параметры
+
+| Имя | Описание | По умолчанию |
+| --- | -------- | ------------ |
+| timestamp | Unix-время. Значение из десяти цифр считается секундами и переводится в миллисекунды. Если число не больше нуля, вернётся `defaultValue`. | |
+| date | При `true` добавляет `MODx.config.manager_date_format`. | `true` |
+| time | При `true` добавляет `MODx.config.manager_time_format`. | `true` |
+| defaultValue | Возвращается при неверном timestamp или когда и `date`, и `time` равны false. | `''` |
+
+## Возвращаемое значение
+
+Отформатированная строка через Ext `Date.format`, либо `defaultValue`.
+
+Если включены и дата, и время, части соединяются одним пробелом.
+
+## Примеры
+
+Дата и время в форматах менеджера:
+
+```javascript
+MODx.util.Format.dateFromTimestamp(1704067200);
+```
+
+Только дата:
+
+```javascript
+MODx.util.Format.dateFromTimestamp(record.data.lastmod, true, false);
+```
+
+Запасная строка, если значения нет:
+
+```javascript
+MODx.util.Format.dateFromTimestamp(0, true, true, _('none'));
+```


### PR DESCRIPTION
## Description

Documents `MODx.util.Format.dateFromTimestamp` for CMP developers: parameters, manager date/time formats, seconds vs milliseconds, and examples. Adds EN and RU pages and links them from the MODExt index (also surfaces the existing breadcrumbs util page).

Matches the helper in `manager/assets/modext/util/utilities.js` from [modxcms/revolution#14873](https://github.com/modxcms/revolution/pull/14873).

## Affected versions

3.x only

## Relevant issues

Fixes #132