### PR TITLE
docs(cli): Add example config.xml for CLI setup

### DIFF
--- a/en/getting-started/installation/cli/config.xml.md
+++ b/en/getting-started/installation/cli/config.xml.md
@@ -6,56 +6,122 @@ _old_uri: "2.x/getting-started/installation/command-line-installation/the-setup-
 
 ## The XML Configuration File
 
-The config.xml file used for running setup via CLI has the following XML nodes. They are described and outlined below:
+CLI setup reads an XML file (usually `setup/config.xml`). Copy `setup/config.dist.new.xml` from a MODX 3.x package, rename it to `config.xml`, and edit the values for your server. You can keep the file outside the web root and point to it with `--config=/path/to/config.xml`.
 
-### Database Configuration Options
+The sample below matches [`setup/config.dist.new.xml`](https://github.com/modxcms/revolution/blob/3.x/setup/config.dist.new.xml) on the 3.x branch. Replace database credentials, admin account, host, and filesystem paths before you run install.
 
-| Key                           | Description                                                                           | Default           |
-| ----------------------------- | ------------------------------------------------------------------------------------- | ----------------- |
-| database\_type                | The database driver to use for this installation.                                     | mysql             |
-| database\_server              | The hostname where your DB server is located. To use a port, postfix with :portnumber | localhost         |
-| database                      | The name of the database                                                              | modx\_modx        |
-| database\_user                | The user to use to connect to the database                                            | db\_username      |
-| database\_password            | The password to use to connect to the database                                        | db\_password      |
-| database\_connection\_charset | The charset to use in the connection to the database                                  | utf8              |
-| database\_charset             | The charset of the database                                                           | utf8              |
-| database\_collation           | The collation of the database                                                         | utf8\_general\_ci |
-| table\_prefix                 | The table prefix to use for all MODX tables                                           | modx\_            |
+### Minimal new-install example
 
-### Installation Configuration Options
+```xml
+<modx>
+    <database_type>mysql</database_type>
+    <database_server>localhost</database_server>
+    <database>modx_modx</database>
+    <database_user>db_username</database_user>
+    <database_password>db_password</database_password>
+    <database_connection_charset>utf8</database_connection_charset>
+    <database_charset>utf8</database_charset>
+    <database_collation>utf8_general_ci</database_collation>
+    <table_prefix>modx_</table_prefix>
+    <https_port>443</https_port>
+    <http_host>localhost</http_host>
 
-| Key                      | Description                                                                                                                                                                                                                                                                     | Default           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| inplace                  | Set this to 1 if you are using MODX from Git or extracted it from the full MODX package to the server prior to installation                                                                                                                                                     |
-| unpacked                 | Set this to 1 if you have manually extracted the core package from the file core/packages/core.transport.zip. This will reduce the time it takes for the installation process on systems that do not allow the PHP time\_limit and script execution time settings to be altered |
-| language                 | The language to install MODX for. This will set the default manager language to this. Use IANA codes.                                                                                                                                                                           |
-| cmsadmin                 | The username of the new Administrator account for new installs                                                                                                                                                                                                                  | username          |
-| cmspassword              | The password of the new Administrator account for new installs                                                                                                                                                                                                                  | password          |
-| cmsadminemail            | The email of the new Administrator account for new installs                                                                                                                                                                                                                     | email@address.com |
-| remove\_setup\_directory | Whether or not to remove the setup/ directory after installation.                                                                                                                                                                                                               | 1                 |
+    <!-- 1 = files already in place (Git checkout or full extract before setup) -->
+    <inplace>0</inplace>
 
-### Path Configuration Options
+    <!-- 1 = core.transport.zip already extracted under core/packages/ -->
+    <unpacked>0</unpacked>
 
-| Key                       | Description | Default |
-| ------------------------- | ----------- | ------- |
-| context\_mgr\_path        |             |         |
-| context\_mgr\_url         |             |         |
-| context\_connectors\_path |             |         |
-| context\_connectors\_url  |             |         |
-| context\_web\_path        |             |         |
-| context\_web\_url         |             |         |
-| assets\_path              |             |         |
-| assets\_url               |             |         |
-| core\_path                |             |         |
-| processors\_path          |             |         |
+    <!-- IANA language code for the default manager language -->
+    <language>en</language>
 
-### Other Configuration Options
+    <cmsadmin>username</cmsadmin>
+    <cmspassword>password</cmspassword>
+    <cmsadminemail>email@address.com</cmsadminemail>
 
-| Key             | Description                                                            | Default   |
-| --------------- | ---------------------------------------------------------------------- | --------- |
-| https\_port     | The port on your server for HTTPS connections                          | 443       |
-| http\_host      | The HTTP host of your server. Usually the hostname, such as mysite.com | localhost |
-| cache\_disabled | Whether or not to disable the MODX cache                               | 0         |
+    <core_path>/www/modx/core/</core_path>
+
+    <context_mgr_path>/www/modx/manager/</context_mgr_path>
+    <context_mgr_url>/modx/manager/</context_mgr_url>
+    <context_connectors_path>/www/modx/connectors/</context_connectors_path>
+    <context_connectors_url>/modx/connectors/</context_connectors_url>
+    <context_web_path>/www/modx/</context_web_path>
+    <context_web_url>/modx/</context_web_url>
+
+    <remove_setup_directory>1</remove_setup_directory>
+</modx>
+```
+
+Then from `setup/`:
+
+```shell
+php ./index.php --installmode=new
+```
+
+See [Command Line Installation](getting-started/installation/cli) for `--config`, upgrades, and `upgrade-advanced`.
+
+### Minimal upgrade example
+
+For `--installmode=upgrade`, `setup/config.dist.upgrade.xml` only needs the keys below (plus any other values you want to change):
+
+```xml
+<modx>
+    <inplace>0</inplace>
+    <unpacked>0</unpacked>
+    <language>en</language>
+    <core_path>/www/modx/core/</core_path>
+    <remove_setup_directory>1</remove_setup_directory>
+</modx>
+```
+
+## Database Configuration Options
+
+| Key | Description | Default |
+| --- | ----------- | ------- |
+| database\_type | The database driver to use for this installation. | mysql |
+| database\_server | The hostname where your DB server is located. To use a port, postfix with `:portnumber`. | localhost |
+| database | The name of the database. | modx\_modx |
+| database\_user | The user to use to connect to the database. | db\_username |
+| database\_password | The password to use to connect to the database. | db\_password |
+| database\_connection\_charset | The charset to use in the connection to the database. | utf8 |
+| database\_charset | The charset of the database. | utf8 |
+| database\_collation | The collation of the database. | utf8\_general\_ci |
+| table\_prefix | The table prefix to use for all MODX tables. | modx\_ |
+
+## Installation Configuration Options
+
+| Key | Description | Default |
+| --- | ----------- | ------- |
+| inplace | Set this to `1` if you are using MODX from Git or extracted the full package to the server before installation. | |
+| unpacked | Set this to `1` if you already extracted `core/packages/core.transport.zip`. Speeds up install when PHP `time_limit` cannot be raised. | |
+| language | Default manager language. Use IANA codes. | |
+| cmsadmin | Username of the new administrator account (new installs). | username |
+| cmspassword | Password of the new administrator account (new installs). | password |
+| cmsadminemail | Email of the new administrator account (new installs). | email@address.com |
+| remove\_setup\_directory | Whether to remove the `setup/` directory after installation. | 1 |
+
+## Path Configuration Options
+
+| Key | Description | Default |
+| --- | ----------- | ------- |
+| core\_path | Absolute path to the `core/` directory. | |
+| context\_mgr\_path | Absolute path to the manager context. | |
+| context\_mgr\_url | URL path to the manager (for example `/modx/manager/`). | |
+| context\_connectors\_path | Absolute path to the connectors directory. | |
+| context\_connectors\_url | URL path to the connectors. | |
+| context\_web\_path | Absolute path to the web root for the `web` context. | |
+| context\_web\_url | URL path to the site root (for example `/modx/`). | |
+| assets\_path | Absolute path to `assets/` (optional; defaults under the web path). | |
+| assets\_url | URL path to `assets/` (optional). | |
+| processors\_path | Absolute path to processors (optional; MODX sets a default). | |
+
+## Other Configuration Options
+
+| Key | Description | Default |
+| --- | ----------- | ------- |
+| https\_port | The port on your server for HTTPS connections. | 443 |
+| http\_host | The HTTP host of your server (hostname, such as `mysite.com`). | localhost |
+| cache\_disabled | Whether to disable the MODX cache. | 0 |
 
 ## See Also
 

--- a/ru/getting-started/installation/cli/config.xml.md
+++ b/ru/getting-started/installation/cli/config.xml.md
@@ -1,68 +1,136 @@
 ---
-title: "Создание Установочного Xml Файла"
+title: "Создание установочного XML-файла"
 translation: "getting-started/installation/cli/config.xml"
 ---
 
-Файл config.xml, используемый для установки через командную строку (CLI), имеет следующие элементы XML:
+## XML-файл конфигурации
 
-## Параметры конфигурации базы данных
+CLI-установка читает XML-файл (обычно `setup/config.xml`). Скопируйте `setup/config.dist.new.xml` из пакета MODX 3.x, переименуйте в `config.xml` и подставьте значения своего сервера. Файл можно держать вне web root и указать через `--config=/path/to/config.xml`.
 
-| Ключ                          | Описание                                                                                                                        | По умолчанию      |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| database\_type                | Используемы драйвер базы данных.                                                                                                | mysql             |
-| database\_server              | Имя хоста, на котором расположен ваш сервер базы данных. Чтобы сменитьпорт по умолчанию укажите его через двоеточие: portnumber | localhost         |
-| database                      | Имя базы данных                                                                                                                 | modx\_modx        |
-| database\_user                | Пользователь базы данных                                                                                                        | db\_username      |
-| database\_password            | Пароль пользователя для доступа к базе данных                                                                                   | db\_password      |
-| database\_connection\_charset | Кодировка, используемая при подключении к базе данных                                                                           | utf8              |
-| database\_charset             | Кодировка базы данных                                                                                                           | utf8              |
-| database\_collation           | Сопоставление базы данных                                                                                                       | utf8\_general\_ci |
-| table\_prefix                 | Префикс таблицы, используемый для всех таблиц MODX                                                                              | modx\_            |
+Пример ниже совпадает с [`setup/config.dist.new.xml`](https://github.com/modxcms/revolution/blob/3.x/setup/config.dist.new.xml) в ветке 3.x. Перед установкой замените доступ к БД, учётку администратора, хост и пути на диске.
+
+### Минимальный пример новой установки
+
+```xml
+<modx>
+    <database_type>mysql</database_type>
+    <database_server>localhost</database_server>
+    <database>modx_modx</database>
+    <database_user>db_username</database_user>
+    <database_password>db_password</database_password>
+    <database_connection_charset>utf8</database_connection_charset>
+    <database_charset>utf8</database_charset>
+    <database_collation>utf8_general_ci</database_collation>
+    <table_prefix>modx_</table_prefix>
+    <https_port>443</https_port>
+    <http_host>localhost</http_host>
+
+    <!-- 1 = файлы уже на месте (Git или полная распаковка до setup) -->
+    <inplace>0</inplace>
+
+    <!-- 1 = core.transport.zip уже распакован в core/packages/ -->
+    <unpacked>0</unpacked>
+
+    <!-- Код языка IANA для языка менеджера по умолчанию -->
+    <language>ru</language>
+
+    <cmsadmin>username</cmsadmin>
+    <cmspassword>password</cmspassword>
+    <cmsadminemail>email@address.com</cmsadminemail>
+
+    <core_path>/www/modx/core/</core_path>
+
+    <context_mgr_path>/www/modx/manager/</context_mgr_path>
+    <context_mgr_url>/modx/manager/</context_mgr_url>
+    <context_connectors_path>/www/modx/connectors/</context_connectors_path>
+    <context_connectors_url>/modx/connectors/</context_connectors_url>
+    <context_web_path>/www/modx/</context_web_path>
+    <context_web_url>/modx/</context_web_url>
+
+    <remove_setup_directory>1</remove_setup_directory>
+</modx>
+```
+
+Затем из каталога `setup/`:
+
+```shell
+php ./index.php --installmode=new
+```
+
+См. [установку из командной строки](getting-started/installation/cli) про `--config`, апгрейд и `upgrade-advanced`.
+
+### Минимальный пример апгрейда
+
+Для `--installmode=upgrade` в `setup/config.dist.upgrade.xml` достаточно ключей ниже (и любых других значений, которые хотите изменить):
+
+```xml
+<modx>
+    <inplace>0</inplace>
+    <unpacked>0</unpacked>
+    <language>ru</language>
+    <core_path>/www/modx/core/</core_path>
+    <remove_setup_directory>1</remove_setup_directory>
+</modx>
+```
+
+## Параметры базы данных
+
+| Ключ | Описание | По умолчанию |
+| ---- | -------- | ------------ |
+| database\_type | Драйвер базы данных. | mysql |
+| database\_server | Хост сервера БД. Порт укажите через двоеточие: `хост:порт`. | localhost |
+| database | Имя базы данных. | modx\_modx |
+| database\_user | Пользователь БД. | db\_username |
+| database\_password | Пароль пользователя БД. | db\_password |
+| database\_connection\_charset | Кодировка соединения с БД. | utf8 |
+| database\_charset | Кодировка базы данных. | utf8 |
+| database\_collation | Collation базы данных. | utf8\_general\_ci |
+| table\_prefix | Префикс таблиц MODX. | modx\_ |
 
 ## Параметры установки
 
-| Key                      | Description                                                                                                                                                                                                               | Default           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| inplace                  | Установите значение 1, если вы используете MODX из Git или извлекли его из пакета MODX                                                                                                                                    |
-| unpacked                 | Установите значение 1, если вы вручную извлекли ядро из файла core/packages/core.transport.zip. Это сократит время, необходимое для установки в системах, которые не позволяют изменять настройки времени PHP time\_limit |
-| language                 | Язык установки MODX. Этот параметр установит язык менеджера по умолчанию. Используйте коды IANA.                                                                                                                          |
-| cmsadmin                 | Имя пользователя администратора, который будет создан после установки                                                                                                                                                     | username          |
-| cmspassword              | Пароль учетной записи администратора (для новых установок)                                                                                                                                                                | password          |
-| cmsadminemail            | Электронный адрес новой учетной записи администратора (для новых установок)                                                                                                                                               | email@address.com |
-| remove\_setup\_directory | Следует ли удалять каталог setup/ после установки.                                                                                                                                                                        | 1                 |
+| Ключ | Описание | По умолчанию |
+| ---- | -------- | ------------ |
+| inplace | `1`, если вы ставите из Git или уже распаковали полный пакет на сервер до запуска setup. | |
+| unpacked | `1`, если уже распаковали `core/packages/core.transport.zip`. Ускоряет установку, когда нельзя поднять PHP `time_limit`. | |
+| language | Язык менеджера по умолчанию. Коды IANA. | |
+| cmsadmin | Логин нового администратора (новая установка). | username |
+| cmspassword | Пароль нового администратора (новая установка). | password |
+| cmsadminemail | Email нового администратора (новая установка). | email@address.com |
+| remove\_setup\_directory | Удалять ли каталог `setup/` после установки. | 1 |
 
-## Конфигурация пути
+## Параметры путей
 
-| Key                       | Description | Default |
-| ------------------------- | ----------- | ------- |
-| context\_mgr\_path        |             |         |
-| context\_mgr\_url         |             |         |
-| context\_connectors\_path |             |         |
-| context\_connectors\_url  |             |         |
-| context\_web\_path        |             |         |
-| context\_web\_url         |             |         |
-| assets\_path              |             |         |
-| assets\_url               |             |         |
-| core\_path                |             |         |
-| processors\_path          |             |         |
+| Ключ | Описание | По умолчанию |
+| ---- | -------- | ------------ |
+| core\_path | Абсолютный путь к каталогу `core/`. | |
+| context\_mgr\_path | Абсолютный путь к менеджеру. | |
+| context\_mgr\_url | URL-путь к менеджеру (например `/modx/manager/`). | |
+| context\_connectors\_path | Абсолютный путь к connectors. | |
+| context\_connectors\_url | URL-путь к connectors. | |
+| context\_web\_path | Абсолютный путь к корню контекста `web`. | |
+| context\_web\_url | URL-путь к корню сайта (например `/modx/`). | |
+| assets\_path | Абсолютный путь к `assets/` (опционально; по умолчанию под web path). | |
+| assets\_url | URL-путь к `assets/` (опционально). | |
+| processors\_path | Абсолютный путь к процессорам (опционально; MODX задаёт значение по умолчанию). | |
 
-## Другие параметры конфигурации
+## Другие параметры
 
-| Key             | Description                                                     | Default   |
-| --------------- | --------------------------------------------------------------- | --------- |
-| https\_port     | Порт для соединения по HTTPS                                    | 443       |
-| http\_host      | HTTP-хост вашего сервера. Обычно имя хоста, например mysite.com | localhost |
-| cache\_disabled | Следует ли отключить кэш MODX                                   | 0         |
+| Ключ | Описание | По умолчанию |
+| ---- | -------- | ------------ |
+| https\_port | Порт HTTPS на сервере. | 443 |
+| http\_host | HTTP-хост сервера (имя хоста, например `mysite.com`). | localhost |
+| cache\_disabled | Отключать ли кэш MODX. | 0 |
 
-## Так же
+## См. также
 
-- [Базовая Установка](getting-started/installation/standard)
+- [Базовая установка](getting-started/installation/standard)
     - [Гид по Lighttpd](getting-started/friendly-urls/lighttpd)
-    - [Установка на сервере с запущеным ModSecurity](getting-started/installation/troubleshooting/modsecurity)
-    - [Настройка Сервера Nginx](getting-started/friendly-urls/nginx)
-- [Расширенная Установка](getting-started/installation/advanced)
+    - [Установка на сервере с ModSecurity](getting-started/installation/troubleshooting/modsecurity)
+    - [Настройка Nginx](getting-started/friendly-urls/nginx)
+- [Расширенная установка](getting-started/installation/advanced)
 - [Установка через Git](getting-started/installation/git)
-- [Установка При Помощи Командной Строки](getting-started/installation/cli)
-    - [Создание Установочного Xml Файла](getting-started/installation/cli/config.xml)
+- [Установка из командной строки](getting-started/installation/cli)
+    - [Создание установочного XML-файла](getting-started/installation/cli/config.xml)
 - [Устранение неполадок при установке](getting-started/installation/troubleshooting)
-- [Успешная Установка, Что Дальше?](getting-started/getting-started)
+- [Успешная установка, что дальше?](getting-started/getting-started)

--- a/ru/getting-started/installation/cli/config.xml.md
+++ b/ru/getting-started/installation/cli/config.xml.md
@@ -110,9 +110,9 @@ php ./index.php --installmode=new
 | context\_connectors\_url | URL-путь к connectors. | |
 | context\_web\_path | Абсолютный путь к корню контекста `web`. | |
 | context\_web\_url | URL-путь к корню сайта (например `/modx/`). | |
-| assets\_path | Абсолютный путь к `assets/` (опционально; по умолчанию под web path). | |
+| assets\_path | Абсолютный путь к `assets/` (опционально, по умолчанию под web path). | |
 | assets\_url | URL-путь к `assets/` (опционально). | |
-| processors\_path | Абсолютный путь к процессорам (опционально; MODX задаёт значение по умолчанию). | |
+| processors\_path | Абсолютный путь к процессорам (опционально, MODX задаёт значение по умолчанию). | |
 
 ## Другие параметры
 


### PR DESCRIPTION
## Description

Adds copy-pasteable `config.xml` samples for CLI setup: a full new-install example and a minimal upgrade example. Samples match `setup/config.dist.new.xml` and `setup/config.dist.upgrade.xml` on Revolution 3.x. Also fills empty path option descriptions and cleans the Russian option tables.

## Affected versions

3.x (XML matches the 3.x dist files; CLI install exists since 2.2)

## Relevant issues

Fixes #224