### PR TITLE
docs(furls): Document alias transliteration

### DIFF
--- a/en/building-sites/settings/friendly_alias_translit.md
+++ b/en/building-sites/settings/friendly_alias_translit.md
@@ -11,4 +11,10 @@ _old_uri: "2.x/administering-your-site/settings/system-settings/friendly_alias_t
 **Default**: none
 **Available In**: Revolution 2.0.8+
 
-The method of transliteration to use on an alias specified for a Resource. Empty or "none" is the default which skips transliteration. Other possible values are "iconv" (if available) or a named transliteration table provided by a custom transliteration service class, specified in [friendly\_alias\_translit\_class](building-sites/settings/friendly_alias_translit_class "friendly_alias_translit_class").
+The method of transliteration to use on an alias specified for a Resource. Empty or `none` skips transliteration (stock default). Other values:
+
+- `iconv` (if the PHP extension is available)
+- `iconv_ascii` (force ASCII via iconv)
+- a named transliteration table from a service class such as the [Translit](https://extras.modx.com/package/translit) extra (for example `russian`)
+
+The service class is set in [friendly\_alias\_translit\_class](building-sites/settings/friendly_alias_translit_class). How-to guide: [Alias transliteration](getting-started/friendly-urls/transliteration).

--- a/en/getting-started/friendly-urls.md
+++ b/en/getting-started/friendly-urls.md
@@ -38,6 +38,8 @@ With **Use Friendly Alias Path** set to No, aliases behave as if every Resource 
 
 Container Resources (folders in the tree) use the [container_suffix](building-sites/settings/container_suffix) setting (default `/`) instead of the old `friendly_url_prefix` / `friendly_url_suffix` settings, which were removed in favour of [Content Types](building-sites/resources/content-types).
 
+For non-Latin pagetitles, configure alias transliteration (`friendly_alias_translit`, iconv, or the Translit extra): [Alias transliteration](getting-started/friendly-urls/transliteration).
+
 ## 3. Add a base href in your Templates
 
 Put this in the `<head>` of every Template that serves HTML:
@@ -72,6 +74,7 @@ On nginx, put equivalent `return 301` logic in the matching `server` blocks.
 
 ## Related
 
+- [Alias transliteration](getting-started/friendly-urls/transliteration)
 - [Server Requirements](getting-started/server-requirements)
 - [Content Types](building-sites/resources/content-types)
 - [Troubleshooting Installation](getting-started/installation/troubleshooting)

--- a/en/getting-started/friendly-urls/transliteration.md
+++ b/en/getting-started/friendly-urls/transliteration.md
@@ -1,0 +1,80 @@
+---
+title: "Alias transliteration"
+description: "How MODX turns non-Latin page titles into Friendly URL aliases"
+---
+
+## What transliteration is
+
+When MODX builds a Resource alias from a pagetitle (or when you type an alias), it can map non-ASCII characters to ASCII-friendly ones. That is transliteration: `Кафе` can become `kafe`, `Straße` can become `Strasse`, depending on the method you choose.
+
+Without transliteration, character restrictions may strip letters and leave broken or empty aliases. With Friendly URLs on, clean aliases keep URLs readable.
+
+MODX applies transliteration inside `modResource::filterPathSegment()` when it generates or filters alias path segments. The same pipeline powers the manager’s real-time alias field and the [`filterPathSegment`](building-sites/tag-syntax/output-filters) output filter.
+
+## Settings involved
+
+Open **System Settings**, area **Friendly URL** (search for `friendly_alias`):
+
+| Setting | Role |
+| ------- | ---- |
+| [friendly\_alias\_translit](building-sites/settings/friendly_alias_translit) | Which method to use: `none`, `iconv`, `iconv_ascii`, or a named table from an extra |
+| [friendly\_alias\_translit\_class](building-sites/settings/friendly_alias_translit_class) | Service class for named tables (default `translit.modTransliterate`) |
+| [friendly\_alias\_translit\_class\_path](building-sites/settings/friendly_alias_translit_class_path) | Where to load that class (default `{core_path}components/`) |
+| [automatic\_alias](building-sites/settings/automatic_alias) | Generate the alias from the pagetitle on save when the alias is empty |
+
+Related filters (word delimiters, lowercase, max length, restrict chars) run after transliteration. See the other `friendly_alias_*` settings in the same area.
+
+Default for `friendly_alias_translit` in a stock install is `none` (no transliteration). The PHP fallback in code uses `iconv` when the extension exists and the setting is unset. Set the value explicitly so behaviour is obvious.
+
+## Built-in: none
+
+Leave `friendly_alias_translit` empty or set it to `none`. MODX does not map characters. Use this when titles are already ASCII or you type aliases by hand.
+
+## Built-in: iconv
+
+Set `friendly_alias_translit` to `iconv`. Requires the PHP `iconv` extension.
+
+MODX runs something equivalent to converting the string with `//TRANSLIT//IGNORE` into the site charset (`modx_charset`, usually UTF-8). Quality depends on your PHP/iconv build and locale. It is a quick option without extras, not a language-specific table.
+
+### iconv\_ascii
+
+Set `friendly_alias_translit` to `iconv_ascii` to force transliteration toward ASCII (`ASCII//TRANSLIT//IGNORE`). Use this when you want Latin-only URL segments and `iconv` alone still leaves non-ASCII characters.
+
+## Named tables: the Translit extra
+
+For predictable language tables (Russian and others), install the [Translit](https://extras.modx.com/package/translit) package from Package Management. It ships `translit.modTransliterate`, which is already the default class name in core settings.
+
+Typical setup after install:
+
+1. Install **translit**.
+2. Set `friendly_alias_translit_class` to `translit.modTransliterate` (usually already set).
+3. Set `friendly_alias_translit_class_path` to `{core_path}components/` (default).
+4. Set `friendly_alias_translit` to the table name, for example `russian` (not `iconv`).
+5. Turn `automatic_alias` on if you want aliases created from pagetitles.
+6. Clear the site cache.
+
+The value of `friendly_alias_translit` is the **table name** the service loads (file name without `.php` under the Translit tables). Other tables or a custom copy (for example `custom`) work the same way: put the table name in the setting.
+
+Other extras (Translitor, yTranslit, and similar) may register their own class or settings. Follow that package’s docs, then point `friendly_alias_translit_class` / path at its service if required.
+
+## Check that it works
+
+1. Enable [friendly\_urls](building-sites/settings/friendly_urls) and configure the web server rewrite rules ([Friendly URLs guide](getting-started/friendly-urls)).
+2. Create a Resource whose pagetitle contains non-Latin characters.
+3. Save (with `automatic_alias` on, or copy the suggested alias).
+4. Confirm the alias field and the front-end URL use the transliterated form.
+
+Existing Resources keep their stored aliases until you edit and regenerate them. Changing the setting does not rewrite the tree by itself.
+
+## File uploads
+
+In MODX 3.x, [upload\_translit](building-sites/settings/upload_translit) can transliterate uploaded file names using the same global transliteration rules. That is separate from FURL aliases but useful on the same multilingual sites.
+
+## See also
+
+- [Using Friendly URLs](getting-started/friendly-urls)
+- [friendly\_alias\_translit](building-sites/settings/friendly_alias_translit)
+- [friendly\_alias\_translit\_class](building-sites/settings/friendly_alias_translit_class)
+- [friendly\_alias\_translit\_class\_path](building-sites/settings/friendly_alias_translit_class_path)
+- [upload\_translit](building-sites/settings/upload_translit)
+- [Translit on extras.modx.com](https://extras.modx.com/package/translit)

--- a/en/getting-started/friendly-urls/transliteration.md
+++ b/en/getting-started/friendly-urls/transliteration.md
@@ -24,7 +24,7 @@ Open **System Settings**, area **Friendly URL** (search for `friendly_alias`):
 
 Related filters (word delimiters, lowercase, max length, restrict chars) run after transliteration. See the other `friendly_alias_*` settings in the same area.
 
-Default for `friendly_alias_translit` in a stock install is `none` (no transliteration). The PHP fallback in code uses `iconv` when the extension exists and the setting is unset. Set the value explicitly so behaviour is obvious.
+Default for `friendly_alias_translit` in a stock install is `none` (no transliteration). The PHP fallback in code uses `iconv` when the extension exists and the setting is unset. Set the value explicitly so behavior is obvious.
 
 ## Built-in: none
 

--- a/es/getting-started/friendly-urls.md
+++ b/es/getting-started/friendly-urls.md
@@ -149,6 +149,8 @@ La configuración Usar la Ruta de Alias Amigable (use\ _alias\ _path) permite qu
 
 La configuración friendly\_alias\_urls se eliminó en MODX 2.1+. Habilitar friendly\ _urls implica que está usando friendly\ _alias\ _urls en 2.1+ y esta configuración ya no era útil ni necesaria.
 
+Para títulos no latinos, configura la transliteración de alias (`friendly_alias_translit`, iconv o el extra Translit): [Transliteración de alias](getting-started/friendly-urls/transliteration).
+
 ## 3) Edita tu(s) plantilla(s)
 
 Asegúrate de tener la siguiente etiqueta en la sección principal de todas tus plantillas. Si solo tienes un contexto front-end (por ejemplo, 'web'), generalmente puedes omitir el signo de exclamación para acelerar la carga de la página:

--- a/es/getting-started/friendly-urls/transliteration.md
+++ b/es/getting-started/friendly-urls/transliteration.md
@@ -14,7 +14,7 @@ MODX aplica la transliteración en `modResource::filterPathSegment()` al generar
 
 ## Ajustes implicados
 
-Abre **System Settings**, área **Friendly URL** (busca `friendly_alias`):
+Abre **Configuración del Sistema**, área **URL amigable** (busca `friendly_alias`):
 
 | Ajuste | Función |
 | ------ | ------- |

--- a/es/getting-started/friendly-urls/transliteration.md
+++ b/es/getting-started/friendly-urls/transliteration.md
@@ -1,0 +1,81 @@
+---
+title: "Transliteración de alias"
+translation: "getting-started/friendly-urls/transliteration"
+description: "Cómo MODX convierte títulos no latinos en alias de Friendly URLs"
+---
+
+## Qué es la transliteración
+
+Cuando MODX construye el alias de un Resource a partir del pagetitle (o cuando escribes el alias), puede mapear caracteres no ASCII a formas aptas para URL. Eso es transliteración: `Кафе` puede pasar a `kafe`, `Straße` a `Strasse`, según el método elegido.
+
+Sin transliteración, las restricciones de caracteres pueden eliminar letras y dejar alias rotos o vacíos. Con Friendly URLs activos, los alias limpios mantienen URLs legibles.
+
+MODX aplica la transliteración en `modResource::filterPathSegment()` al generar o filtrar segmentos de ruta. El mismo flujo alimenta el campo alias en el manager en tiempo real y el filtro de salida [`filterPathSegment`](building-sites/tag-syntax/output-filters).
+
+## Ajustes implicados
+
+Abre **System Settings**, área **Friendly URL** (busca `friendly_alias`):
+
+| Ajuste | Función |
+| ------ | ------- |
+| [friendly\_alias\_translit](building-sites/settings/friendly_alias_translit) | Método: `none`, `iconv`, `iconv_ascii` o una tabla con nombre de un extra |
+| [friendly\_alias\_translit\_class](building-sites/settings/friendly_alias_translit_class) | Clase de servicio para tablas con nombre (por defecto `translit.modTransliterate`) |
+| [friendly\_alias\_translit\_class\_path](building-sites/settings/friendly_alias_translit_class_path) | Ruta desde la que cargar esa clase (por defecto `{core_path}components/`) |
+| [automatic\_alias](building-sites/settings/automatic_alias) | Generar el alias desde el pagetitle al guardar si el alias está vacío |
+
+Los filtros relacionados (delimitadores, minúsculas, longitud, restricción de caracteres) se aplican después de la transliteración. Revisa el resto de `friendly_alias_*` en la misma área.
+
+En una instalación estándar, `friendly_alias_translit` vale `none`. En el código, si el ajuste no está definido y existe `iconv`, el respaldo es `iconv`. Define el valor a propósito para que el comportamiento quede claro.
+
+## Integrado: none
+
+Deja `friendly_alias_translit` vacío o pon `none`. No hay mapeo de caracteres. Úsalo si los títulos ya son ASCII o escribes los alias a mano.
+
+## Integrado: iconv
+
+Pon `friendly_alias_translit` en `iconv`. Requiere la extensión PHP `iconv`.
+
+MODX convierte la cadena con `//TRANSLIT//IGNORE` al charset del sitio (`modx_charset`, normalmente UTF-8). La calidad depende de tu build de PHP/iconv y de la locale. Es una opción rápida sin extras, no una tabla por idioma.
+
+### iconv\_ascii
+
+Con `iconv_ascii` la conversión apunta a ASCII (`ASCII//TRANSLIT//IGNORE`). Úsalo si quieres segmentos solo latinos y `iconv` todavía deja caracteres no ASCII.
+
+## Tablas con nombre: el extra Translit
+
+Para tablas lingüísticas predecibles (ruso y otras), instala el paquete [Translit](https://extras.modx.com/package/translit) desde Package Management. Incluye `translit.modTransliterate`, que ya es el nombre de clase por defecto en el core.
+
+Configuración habitual tras instalar:
+
+1. Instala **translit**.
+2. `friendly_alias_translit_class` = `translit.modTransliterate` (suele estar así).
+3. `friendly_alias_translit_class_path` = `{core_path}components/` (por defecto).
+4. `friendly_alias_translit` = nombre de tabla, por ejemplo `russian` (no `iconv`).
+5. Activa `automatic_alias` si quieres alias desde el pagetitle.
+6. Vacía la caché del sitio.
+
+El valor de `friendly_alias_translit` es el **nombre de la tabla** que carga el servicio (nombre de archivo sin `.php`). Otras tablas o una copia propia (por ejemplo `custom`) funcionan igual.
+
+Otros extras (Translitor, yTranslit, etc.) pueden registrar su propia clase. Sigue su documentación y apunta `friendly_alias_translit_class` / path a su servicio si hace falta.
+
+## Comprobar que funciona
+
+1. Activa [friendly\_urls](building-sites/settings/friendly_urls) y configura el rewrite ([guía de Friendly URLs](getting-started/friendly-urls)).
+2. Crea un Resource cuyo pagetitle tenga caracteres no latinos.
+3. Guarda (con `automatic_alias` o acepta el alias sugerido).
+4. Confirma el campo alias y la URL pública.
+
+Los Resources ya guardados mantienen su alias hasta que lo regeneres. Cambiar el ajuste no reescribe el árbol solo.
+
+## Subida de archivos
+
+En MODX 3.x, [upload\_translit](building-sites/settings/upload_translit) puede transliterar nombres de archivos subidos con las mismas reglas globales. Es independiente de los alias FURL, pero útil en los mismos sitios multilingües.
+
+## Ver también
+
+- [Usando las URLs amigables](getting-started/friendly-urls)
+- [friendly\_alias\_translit](building-sites/settings/friendly_alias_translit)
+- [friendly\_alias\_translit\_class](building-sites/settings/friendly_alias_translit_class)
+- [friendly\_alias\_translit\_class\_path](building-sites/settings/friendly_alias_translit_class_path)
+- [upload\_translit](building-sites/settings/upload_translit)
+- [Translit en extras.modx.com](https://extras.modx.com/package/translit)

--- a/ru/building-sites/settings/friendly_alias_translit.md
+++ b/ru/building-sites/settings/friendly_alias_translit.md
@@ -10,4 +10,10 @@ translation: "building-sites/settings/friendly_alias_translit"
 -   **По умолчанию**: none
 -   **Доступно в**: Revolution 2.0.8+
 
-Метод транслитерации для использования на псевдониме, указанном для ресурса. Пусто или «нет» - это значение по умолчанию, которое пропускает транслитерацию. Другими возможными значениями являются «iconv» (если доступно) или именованная таблица транслитерации, предоставляемая пользовательским классом обслуживания транслитерации, указанным в [friendly_alias_translit_class](building-sites/settings/friendly_alias_translit_class "friendly_alias_translit_class").
+Метод транслитерации для псевдонима ресурса. Пустое значение или `none` отключает транслитерацию (значение по умолчанию в поставке). Другие варианты:
+
+- `iconv` (если есть расширение PHP)
+- `iconv_ascii` (принудительно в ASCII через iconv)
+- имя таблицы из сервисного класса, например пакета [Translit](https://extras.modx.com/package/translit) (`russian` и т.п.)
+
+Класс сервиса задаётся в [friendly\_alias\_translit\_class](building-sites/settings/friendly_alias_translit_class). Гайд: [Транслитерация псевдонимов](getting-started/friendly-urls/transliteration).

--- a/ru/getting-started/friendly-urls.md
+++ b/ru/getting-started/friendly-urls.md
@@ -39,6 +39,8 @@ translation: "getting-started/friendly-urls"
 
 Контейнерные ресурсы (папки в дереве) используют настройку [container_suffix](building-sites/settings/container_suffix) (по умолчанию `/`) вместо старых `friendly_url_prefix` и `friendly_url_suffix`, которые убрали в пользу [типов контента](building-sites/resources/content-types).
 
+Для нелатинских заголовков настройте транслитерацию псевдонимов (`friendly_alias_translit`, iconv или пакет Translit): [Транслитерация псевдонимов](getting-started/friendly-urls/transliteration).
+
 ## 3. Добавьте base href в шаблоны
 
 Поместите это в `<head>` каждого шаблона, который отдаёт HTML:
@@ -73,6 +75,7 @@ translation: "getting-started/friendly-urls"
 
 ## См. также
 
+- [Транслитерация псевдонимов](getting-started/friendly-urls/transliteration)
 - [Требования к серверу](getting-started/server-requirements)
 - [Типы контента](building-sites/resources/content-types)
 - [Устранение неполадок при установке](getting-started/installation/troubleshooting)

--- a/ru/getting-started/friendly-urls/transliteration.md
+++ b/ru/getting-started/friendly-urls/transliteration.md
@@ -1,0 +1,81 @@
+---
+title: "Транслитерация псевдонимов"
+translation: "getting-started/friendly-urls/transliteration"
+description: "Как MODX превращает нелатинские заголовки в псевдонимы для Friendly URLs"
+---
+
+## Что такое транслитерация
+
+Когда MODX строит псевдоним (alias) ресурса из pagetitle (или когда вы вводите alias), он может заменить не-ASCII символы на удобные для URL. Это и есть транслитерация: `Кафе` станет `kafe`, `Straße` может стать `Strasse`, в зависимости от выбранного метода.
+
+Без транслитерации ограничения по символам могут вырезать буквы и оставить битый или пустой alias. При включённых Friendly URLs чистые псевдонимы дают читаемые адреса.
+
+MODX применяет транслитерацию в `modResource::filterPathSegment()` при генерации и фильтрации сегментов пути. Тот же пайплайн кормит поле alias в менеджере в реальном времени и output-фильтр [`filterPathSegment`](building-sites/tag-syntax/output-filters).
+
+## Какие настройки участвуют
+
+Откройте **Системные настройки**, область **Friendly URL** (поиск по `friendly_alias`):
+
+| Настройка | Назначение |
+| --------- | ---------- |
+| [friendly\_alias\_translit](building-sites/settings/friendly_alias_translit) | Метод: `none`, `iconv`, `iconv_ascii` или имя таблицы из дополнения |
+| [friendly\_alias\_translit\_class](building-sites/settings/friendly_alias_translit_class) | Сервисный класс для именованных таблиц (по умолчанию `translit.modTransliterate`) |
+| [friendly\_alias\_translit\_class\_path](building-sites/settings/friendly_alias_translit_class_path) | Откуда грузить класс (по умолчанию `{core_path}components/`) |
+| [automatic\_alias](building-sites/settings/automatic_alias) | Генерировать alias из pagetitle при сохранении, если поле пустое |
+
+Связанные фильтры (разделители слов, нижний регистр, длина, ограничение символов) работают после транслитерации. Смотрите остальные `friendly_alias_*` в той же области.
+
+В стандартной установке `friendly_alias_translit` равен `none` (без транслитерации). В коде, если настройка не задана и есть расширение iconv, запасной вариант: `iconv`. Задайте значение явно, чтобы поведение было понятным.
+
+## Встроенный вариант: none
+
+Оставьте `friendly_alias_translit` пустым или поставьте `none`. Символы не маппятся. Так делают, когда заголовки уже в ASCII или alias вводите вручную.
+
+## Встроенный вариант: iconv
+
+Поставьте `friendly_alias_translit` в `iconv`. Нужно расширение PHP `iconv`.
+
+MODX конвертирует строку с флагами `//TRANSLIT//IGNORE` в кодировку сайта (`modx_charset`, обычно UTF-8). Качество зависит от сборки PHP/iconv и локали. Это быстрый вариант без пакетов, не языковая таблица.
+
+### iconv\_ascii
+
+Значение `iconv_ascii` гонит строку в ASCII (`ASCII//TRANSLIT//IGNORE`). Берите его, если нужны только латинские сегменты URL, а обычный `iconv` всё ещё оставляет не-ASCII.
+
+## Именованные таблицы: пакет Translit
+
+Для стабильных языковых таблиц (русский и другие) установите пакет [Translit](https://extras.modx.com/package/translit) через Управление пакетами. Он даёт класс `translit.modTransliterate`, который уже указан в настройках ядра по умолчанию.
+
+Типичная настройка после установки:
+
+1. Установите **translit**.
+2. `friendly_alias_translit_class` = `translit.modTransliterate` (обычно уже так).
+3. `friendly_alias_translit_class_path` = `{core_path}components/` (по умолчанию).
+4. `friendly_alias_translit` = имя таблицы, например `russian` (не `iconv`).
+5. Включите `automatic_alias`, если alias должен создаваться из pagetitle.
+6. Очистите кэш сайта.
+
+Значение `friendly_alias_translit`: **имя таблицы**, которую грузит сервис (имя файла без `.php` в таблицах Translit). Другие таблицы или своя копия (например `custom`) работают так же: в настройку пишете имя таблицы.
+
+Другие дополнения (Translitor, yTranslit и похожие) могут ставить свой класс или свои настройки. Следуйте их документации и при необходимости укажите `friendly_alias_translit_class` / path на их сервис.
+
+## Проверка
+
+1. Включите [friendly\_urls](building-sites/settings/friendly_urls) и настройте rewrite ([гайд по Friendly URLs](getting-started/friendly-urls)).
+2. Создайте ресурс с нелатинским pagetitle.
+3. Сохраните (с `automatic_alias` или подставьте предложенный alias).
+4. Убедитесь, что поле alias и URL на сайте в транслите.
+
+Уже сохранённые ресурсы держат старый alias, пока вы его не перегенерируете. Смена настройки сама по себе дерево не переписывает.
+
+## Загрузка файлов
+
+В MODX 3.x настройка [upload\_translit](building-sites/settings/upload_translit) может транслитерировать имена загружаемых файлов по тем же глобальным правилам. Это отдельно от FURL-псевдонимов, но полезно на тех же мультиязычных сайтах.
+
+## См. также
+
+- [Использование дружественных URL](getting-started/friendly-urls)
+- [friendly\_alias\_translit](building-sites/settings/friendly_alias_translit)
+- [friendly\_alias\_translit\_class](building-sites/settings/friendly_alias_translit_class)
+- [friendly\_alias\_translit\_class\_path](building-sites/settings/friendly_alias_translit_class_path)
+- [upload\_translit](building-sites/settings/upload_translit)
+- [Translit на extras.modx.com](https://extras.modx.com/package/translit)


### PR DESCRIPTION
## Description

Documents what Friendly URL alias transliteration is and how to configure it: built-in `none` / `iconv` / `iconv_ascii`, the Translit extra with named tables (for example `russian`), related system settings, verification steps, and `upload_translit` for file names in 3.x.

Aligned with `modResource::filterPathSegment()` and core system setting defaults on Revolution 3.x. New guide under Getting Started > Friendly URLs in en, ru, and es, with links from the main FURL pages and updated `friendly_alias_translit` setting docs.

## Affected versions

2.x and 3.x (`friendly_alias_translit` since 2.0.8; `upload_translit` called out for 3.x)

## Relevant issues

Fixes #161