### PR TITLE
docs(xpdo): Fix isDirty examples to require field key

### DIFF
--- a/en/extending-modx/xpdo/class-reference/xpdoobject/state-accessors/isdirty.md
+++ b/en/extending-modx/xpdo/class-reference/xpdoobject/state-accessors/isdirty.md
@@ -6,7 +6,7 @@ _old_uri: "2.x/class-reference/xpdoobject/state-accessors/isdirty"
 
 ## xPDOObject::isDirty()
 
-Indicates if an object field has been modified (or never saved).
+Indicates if an object **field** has been modified (or the object has never been saved). You must pass the field name. There is no overload that checks the whole object.
 
 ## Syntax
 
@@ -16,16 +16,36 @@ API Docs: <http://api.modxcms.com/xpdo/om/xPDOObject.html#isDirty>
 boolean isDirty (string $key)
 ```
 
+- `$key` — field name to check (required).
+
+Returns `true` when the field exists and either appears in the object's dirty map or the object is new (`isNew()`). Returns `false` when the field exists and is unchanged on a persisted object. Unknown field names return `false` and write an error to the xPDO log.
+
 ## Examples
 
-Test if a Skrewt object has been modified.
+Test whether one field on a Skrewt object changed:
 
 ``` php
-$skrewt = $xpdo->getObject('Skrewt',1);
+$skrewt = $xpdo->getObject('Skrewt', 1);
 
-echo $skrewt->isDirty() ? 1 : 0; // prints 0
+echo $skrewt->isDirty('poisonous') ? 1 : 0; // prints 0
 
-$skrewt->set('poisonous',false);
+$skrewt->set('poisonous', false);
 
-echo $skrewt->isDirty() ? 1 : 0; // prints 1
+echo $skrewt->isDirty('poisonous') ? 1 : 0; // prints 1
 ```
+
+### Any dirty fields
+
+xPDO has no `isDirty()` call without `$key`. To see if the object has any pending field changes, inspect the public `$_dirty` map:
+
+``` php
+if (!empty($skrewt->_dirty)) {
+    echo 'Skrewt has dirty fields.';
+} else {
+    echo 'Skrewt has no dirty fields.';
+}
+
+print_r($skrewt->_dirty);
+```
+
+`$_dirty` lists modified field keys. Saving the object clears it. For new objects, `isDirty($key)` is `true` for every known field even before you call `set()`, because `isNew()` is still true.

--- a/ru/extending-modx/xpdo/class-reference/xpdoobject/state-accessors/isdirty.md
+++ b/ru/extending-modx/xpdo/class-reference/xpdoobject/state-accessors/isdirty.md
@@ -5,7 +5,7 @@ translation: "extending-modx/xpdo/class-reference/xpdoobject/state-accessors/isd
 
 ## xPDOObject::isDirty()
 
-Указывает, было ли поле объекта изменено (или никогда не сохранено).
+Показывает, изменено ли **поле** объекта (или объект ещё ни разу не сохраняли). Имя поля обязательно. Перегрузки «грязный ли весь объект» нет.
 
 ## Синтаксис
 
@@ -15,16 +15,36 @@ API Docs: <http://api.modxcms.com/xpdo/om/xPDOObject.html#isDirty>
 boolean isDirty (string $key)
 ```
 
+- `$key` — имя поля (обязательный аргумент).
+
+Возвращает `true`, если поле существует и либо есть в карте dirty-полей, либо объект новый (`isNew()`). Возвращает `false`, если поле существует и не менялось у уже сохранённого объекта. Неизвестное имя поля даёт `false` и ошибку в журнале xPDO.
+
 ## Пример
 
-Проверьте, был ли изменен объект Skrewt.
+Проверка одного поля у объекта Skrewt:
 
 ```php
-$skrewt = $xpdo->getObject('Skrewt',1);
+$skrewt = $xpdo->getObject('Skrewt', 1);
 
-echo $skrewt->isDirty() ? 1 : 0; // prints 0
+echo $skrewt->isDirty('poisonous') ? 1 : 0; // выведет 0
 
-$skrewt->set('poisonous',false);
+$skrewt->set('poisonous', false);
 
-echo $skrewt->isDirty() ? 1 : 0; // prints 1
+echo $skrewt->isDirty('poisonous') ? 1 : 0; // выведет 1
 ```
+
+### Есть ли хотя бы одно dirty-поле
+
+Вызова `isDirty()` без `$key` нет. Чтобы узнать, есть ли у объекта незаписанные изменения полей, смотрите публичную карту `$_dirty`:
+
+```php
+if (!empty($skrewt->_dirty)) {
+    echo 'У Skrewt есть dirty-поля.';
+} else {
+    echo 'У Skrewt нет dirty-полей.';
+}
+
+print_r($skrewt->_dirty);
+```
+
+В `$_dirty` лежат ключи изменённых полей. После `save()` карта очищается. У нового объекта `isDirty($key)` вернёт `true` для любого известного поля ещё до `set()`, пока `isNew()` остаётся истинным.


### PR DESCRIPTION
## Description

The `isDirty` examples called `isDirty()` with no argument. On Revolution 3.x / xPDO, `xPDOObject::isDirty($key)` requires a field name; omitting it is a PHP error.

Updates en/ru pages to pass `$key` (e.g. `isDirty('poisonous')`), spell out the return behavior (including `isNew()`), and show how to inspect public `$_dirty` when you need “any dirty field” checks.

## Affected versions

Both (signature and `_dirty` behavior match xPDO in 2.x and 3.x; verified against Revolution 3.x `xPDO/Om/xPDOObject.php`)

## Relevant issues

Fixes #559