### PR TITLE
docs(modext): Fix broken Ext JS links on advanced grid tutorial

### DIFF
--- a/en/extending-modx/custom-manager-pages/modext.md
+++ b/en/extending-modx/custom-manager-pages/modext.md
@@ -129,5 +129,5 @@ Lastly, we create the top toolbar, consisting of a button. The handler creates a
 
 ## See Also
 
-- [ExtJS 3.4 API Documentation](http://docs.sencha.com/ext-js/3-4/#!/api)
-- [ExtJS 3.4 Examples](http://dev.sencha.com/deploy/ext-3.4.0/examples/)
+- [ExtJS 3.4 API Documentation](https://docs.sencha.com/extjs/3.4.0/#!/api)
+- [ExtJS 3.4 Examples (GPL CDN)](https://cdn.sencha.com/ext/gpl/3.4.1.1/examples/)

--- a/en/extending-modx/custom-manager-pages/modext/modext-tutorials/7.-ext-js-tutoral-advanced-grid.md
+++ b/en/extending-modx/custom-manager-pages/modext/modext-tutorials/7.-ext-js-tutoral-advanced-grid.md
@@ -149,10 +149,15 @@ You can view the store.php in a browser and you should see some JSON data. If yo
 
 ## See Also
 
-- <http://dev.sencha.com/deploy/ext-3.4.0/examples/grid/paging.html>
-- <http://sottwell.pogwatch.com/datagrid-1.html>
-- <http://sottwell.pogwatch.com/datagrid-2.html>
-- <http://sottwell.pogwatch.com/datagrid-3.html>
+MODX Revolution 3.x still ships Ext JS 3 under `manager/assets/ext3/` (same family as these links).
+
+- [Ext.grid.GridPanel API (Ext JS 3.4)](https://docs.sencha.com/extjs/3.4.0/#!/api/Ext.grid.GridPanel)
+- [Paging grid example (Ext JS 3.4 GPL CDN)](https://cdn.sencha.com/ext/gpl/3.4.1.1/examples/grid/paging.html)
+- [Susan Ottwell — DataGrid part 1 (archive.org)](https://web.archive.org/web/20150307042916/http://sottwell.pogwatch.com/datagrid-1.html)
+- [Susan Ottwell — DataGrid part 2 (archive.org)](https://web.archive.org/web/20150307042916/http://sottwell.pogwatch.com/datagrid-2.html)
+- [Susan Ottwell — DataGrid part 3 (archive.org)](https://web.archive.org/web/20150307042916/http://sottwell.pogwatch.com/datagrid-3.html)
+
+The Ottwell articles are from 2008 (Wayback Machine). Treat them as background reading. Confirm APIs against Ext JS 3.4 and the Manager scripts in your MODX install.
 
 1. [Ext JS Tutorial - Message Boxes](extending-modx/custom-manager-pages/modext/modext-tutorials/1.-ext-js-tutorial-message-boxes)
 2. [Ext JS Tutorial - Ajax Include](extending-modx/custom-manager-pages/modext/modext-tutorials/2.-ext-js-tutorial-ajax-include)

--- a/en/extending-modx/custom-manager-pages/troubleshooting.md
+++ b/en/extending-modx/custom-manager-pages/troubleshooting.md
@@ -23,7 +23,7 @@ _Thanks!!_
 
 Other Resources:
 
-- [ExtJS 3.4.0 Documentation](http://docs.sencha.com/ext-js/3-4/)
+- [ExtJS 3.4.0 Documentation](https://docs.sencha.com/extjs/3.4.0/)
 - [Custom Manager Pages](extending-modx/custom-manager-pages "Custom Manager Pages")
 - [Developing an Extra in MODX Revolution](extending-modx/tutorials/developing-an-extra "Developing an Extra in MODX Revolution") (Specifically [part 2](extending-modx/tutorials/developing-an-extra/part-2 "Developing an Extra in MODX Revolution, Part II"))
 

--- a/ru/extending-modx/custom-manager-pages/modext.md
+++ b/ru/extending-modx/custom-manager-pages/modext.md
@@ -128,5 +128,5 @@ Ext.reg( "mycomponent-grid-mygrid", MyComponent.grid.MyGrid );
 
 ## Смотрите также
 
-- [Документация по API ExtJS 3.4](http://docs.sencha.com/ext-js/3-4/#!/api)
-- [Примеры по ExtJS 3.4](http://dev.sencha.com/deploy/ext-3.4.0/examples/)
+- [Документация по API ExtJS 3.4](https://docs.sencha.com/extjs/3.4.0/#!/api)
+- [Примеры ExtJS 3.4 (GPL CDN)](https://cdn.sencha.com/ext/gpl/3.4.1.1/examples/)

--- a/ru/extending-modx/custom-manager-pages/modext/modext-tutorials/7.-ext-js-tutoral-advanced-grid.md
+++ b/ru/extending-modx/custom-manager-pages/modext/modext-tutorials/7.-ext-js-tutoral-advanced-grid.md
@@ -148,10 +148,15 @@ print json_encode($data);
 
 ## Смотрите также
 
-- [http://dev.sencha.com/deploy/ext-3.4.0/examples/grid/paging.html](http://dev.sencha.com/deploy/ext-3.4.0/examples/grid/paging.html)
-- [http://sottwell.pogwatch.com/datagrid-1.html](http://sottwell.pogwatch.com/datagrid-1.html)
-- [http://sottwell.pogwatch.com/datagrid-2.html](http://sottwell.pogwatch.com/datagrid-2.html)
-- [http://sottwell.pogwatch.com/datagrid-3.html](http://sottwell.pogwatch.com/datagrid-3.html)
+В MODX Revolution 3.x Ext JS 3 лежит в `manager/assets/ext3/` (та же ветка, что у ссылок ниже).
+
+- [Ext.grid.GridPanel API (Ext JS 3.4)](https://docs.sencha.com/extjs/3.4.0/#!/api/Ext.grid.GridPanel)
+- [Пример paging-сетки (Ext JS 3.4 GPL CDN)](https://cdn.sencha.com/ext/gpl/3.4.1.1/examples/grid/paging.html)
+- [Susan Ottwell — DataGrid, часть 1 (archive.org)](https://web.archive.org/web/20150307042916/http://sottwell.pogwatch.com/datagrid-1.html)
+- [Susan Ottwell — DataGrid, часть 2 (archive.org)](https://web.archive.org/web/20150307042916/http://sottwell.pogwatch.com/datagrid-2.html)
+- [Susan Ottwell — DataGrid, часть 3 (archive.org)](https://web.archive.org/web/20150307042916/http://sottwell.pogwatch.com/datagrid-3.html)
+
+Статьи Ottwell — 2008 год (Wayback Machine). Это фон. API сверяйте с Ext JS 3.4 и скриптами Manager в вашей установке MODX.
 
 1. [Ext JS - Окна сообщений](extending-modx/custom-manager-pages/modext/modext-tutorials/1.-ext-js-tutorial-message-boxes)
 2. [Ext JS - Ajax](extending-modx/custom-manager-pages/modext/modext-tutorials/2.-ext-js-tutorial-ajax-include)

--- a/ru/extending-modx/custom-manager-pages/troubleshooting.md
+++ b/ru/extending-modx/custom-manager-pages/troubleshooting.md
@@ -22,7 +22,7 @@ translation: "extending-modx/custom-manager-pages/troubleshooting"
 
 Другие источники:
 
-- [Документация по ExtJS 3.4.0](http://docs.sencha.com/ext-js/3-4/)
+- [Документация по ExtJS 3.4.0](https://docs.sencha.com/extjs/3.4.0/)
 - [Пользовательские страницы менеджера](extending-modx/custom-manager-pages "Custom Manager Pages")
 - [Разработка дополнения в MODX Revolution](extending-modx/tutorials/developing-an-extra "Developing an Extra in MODX Revolution") (в частности, [часть 2](extending-modx/tutorials/developing-an-extra/part-2 "Developing an Extra in MODX Revolution, Part II"))
 


### PR DESCRIPTION
## Description

The Advanced Grid tutorial ended with four dead external URLs (`dev.sencha.com/deploy/...` and `sottwell.pogwatch.com`). Replaced them with working destinations suggested in #386:

- [Ext.grid.GridPanel](https://docs.sencha.com/extjs/3.4.0/#!/api/Ext.grid.GridPanel)
- [Paging grid example on the Ext JS 3.4 GPL CDN](https://cdn.sencha.com/ext/gpl/3.4.1.1/examples/grid/paging.html)
- Ottwell DataGrid parts 1–3 on [archive.org](https://web.archive.org/web/20150307042916/http://sottwell.pogwatch.com/datagrid-1.html)

Also note that Revolution 3.x still ships Ext JS 3 under `manager/assets/ext3/` (verified against `revolution` `3.x`), and that the Ottwell pieces are archival background from 2008.

Same dead Sencha hosts showed up on the MODExt overview and CMP troubleshooting pages (en/ru), so those links were updated in the same pass.

## Affected versions

3.x docs (en, ru). es/nl have no copies of these pages.

## Relevant issues

Fixes #386