### PR TITLE
docs(migxdb): Clarify migxchildresources rename in events CMP tutorial

### DIFF
--- a/en/extras/migxdb/migxdb.tutorials/manage-events-resources-in-a-cmp-with-help-of-migxdb.md
+++ b/en/extras/migxdb/migxdb.tutorials/manage-events-resources-in-a-cmp-with-help-of-migxdb.md
@@ -10,10 +10,11 @@ In this Tuorial we will learn how to create a CMP (custom manager page),  where 
 
 ## Requirements
 
-First off we will need to install [MIGX](extras/migx "MIGX") by package-management, if not allready done, and do some [basic configurations](extras/migxdb/migxdb.configuration "MIGXdb.Configuration").
-Minimum Required version: MIGX 2.3.2 (10.09.2012)
+1. Install [MIGX](extras/migx) from Package Management if you have not already, and complete the [basic MIGXdb configuration](extras/migxdb/migxdb.configuration). Minimum MIGX version: 2.3.2 (10.09.2012).
 
-Download and install this package: [migxchildresources](https://github.com/Bruno17/migxchildresources/tree/master/packages) rename the folder `core/components/migxchildresources/` to `core/components/migxresourceevents/`
+2. Download the [migxchildresources](https://github.com/Bruno17/migxchildresources/tree/master/packages) package from GitHub and install it.
+
+3. Rename the folder `core/components/migxchildresources/` to `core/components/migxresourceevents/`.
 
 ## Create the Configuration
 


### PR DESCRIPTION
## Description

In Requirements, download/install and the folder rename sat on one line after a later markdown tidy. That made the `migxchildresources` link look like part of the rename target (the original bug in #278).

Split into numbered steps: install MIGX, download/install [migxchildresources](https://github.com/Bruno17/migxchildresources/tree/master/packages), then rename `core/components/migxchildresources/` → `core/components/migxresourceevents/`.

Same one-line regression is still on `2.x` / docs.modx.com `current`; this PR targets **3.x** as requested in [the follow-up comment](https://github.com/modxorg/Docs/issues/278#issuecomment-823179086).

## Affected versions

3.x docs (en only; no ru/es/nl copy of this tutorial).

## Relevant issues

Fixes #278