### PR TITLE
docs(maintenance): document session garbage collection (en, ru)

### DIFF
--- a/en/building-sites/settings/session_gc_maxlifetime.md
+++ b/en/building-sites/settings/session_gc_maxlifetime.md
@@ -1,11 +1,13 @@
 ---
 title: "session_gc_maxlifetime"
-description: "Allows customization of the session.gc_maxlifetime PHP ini setting when using modSessionHandler"
+description: "Max age of database sessions before modSessionHandler garbage collection deletes them"
 ---
 
-**Name**: Session Garbage Collector Max Lifetime
-**Type**: String
-**Default**: 604800
+**Name**: Session Garbage Collector Max Lifetime  
+**Type**: String  
+**Default**: 604800  
 **Available In**: Revolution 2.1.1+
 
-Allows customization of the `session.gc_maxlifetime` PHP ini setting when using 'modSessionHandler'.
+Age in seconds after which [`modSessionHandler`](building-sites/settings/session_handler_class) may delete a session row during PHP session garbage collection. Default `604800` is seven days. MODX also applies this value to the PHP `session.gc_maxlifetime` ini setting when it starts the session.
+
+GC only runs when PHP’s `session.gc_probability` / `session.gc_divisor` allow it. On many Debian/Ubuntu hosts probability is `0`, so this setting never takes effect until you fix the server or add a cron. See [Session Garbage Collection](getting-started/maintenance/session-garbage-collection).

--- a/en/getting-started/maintenance.md
+++ b/en/getting-started/maintenance.md
@@ -14,3 +14,4 @@ This could be one of the following:
 1. [Securing / hardening your MODX Site](getting-started/maintenance/securing-modx.md)
 2. [Moving a MODX from one server to another](getting-started/maintenance/moving-your-site.md)
 3. [Upgrading a MODX installation](getting-started/maintenance/upgrading.md)
+4. [Session garbage collection](getting-started/maintenance/session-garbage-collection) (keep `modx_session` from growing unbounded)

--- a/en/getting-started/maintenance/session-garbage-collection.md
+++ b/en/getting-started/maintenance/session-garbage-collection.md
@@ -1,0 +1,134 @@
+---
+title: "Session Garbage Collection"
+description: "Why the modx_session table grows, how PHP session GC works with modSessionHandler, and how to keep sessions pruned"
+---
+
+## Session Garbage Collection
+
+By default Revolution stores sessions in the database with [`MODX\Revolution\modSessionHandler`](building-sites/settings/session_handler_class) (table `{table_prefix}session`, often `modx_session`). PHP must run session garbage collection (GC) on that handler, or expired rows stay forever.
+
+On many hosts, especially Debian and Ubuntu, `session.gc_probability` is `0` because the OS cleans **file** sessions with a cron job. That cron does **not** touch the MODX session table. SiteDash data around 2021 suggested roughly three in ten MODX sites had no working GC. Tables of several gigabytes and dead sites are a known outcome ([modxcms/revolution#16275](https://github.com/modxcms/revolution/issues/16275)).
+
+Setup in current Revolution releases warns when GC probability is zero ([modxcms/revolution#16448](https://github.com/modxcms/revolution/pull/16448)). Existing installs still need a manual check.
+
+### How GC runs
+
+On a share of requests, PHP calls the session handler’s `gc()` method. Probability is:
+
+`session.gc_probability` / `session.gc_divisor`
+
+Example: `1` / `100` means about 1% of requests run GC.
+
+`modSessionHandler::gc()` deletes session rows whose `access` timestamp is older than [`session_gc_maxlifetime`](building-sites/settings/session_gc_maxlifetime) (seconds). Default is `604800` (seven days). That setting also drives `session.gc_maxlifetime` when MODX starts the session.
+
+If `session.gc_probability` is `0`, `gc()` never runs. New visits keep inserting rows. The table only grows.
+
+### Check your server
+
+In SSH or a one-off PHP script:
+
+```bash
+php -i | grep -E 'session.gc_probability|session.gc_divisor|session.gc_maxlifetime'
+```
+
+Or create a temporary PHP file:
+
+```php
+<?php
+header('Content-Type: text/plain');
+foreach (['session.gc_probability', 'session.gc_divisor', 'session.gc_maxlifetime'] as $key) {
+    echo $key, '=', ini_get($key), PHP_EOL;
+}
+```
+
+Remove the file after you read the values.
+
+In MySQL, watch table size and row count:
+
+```sql
+SHOW TABLE STATUS LIKE 'modx_session';
+SELECT COUNT(*) FROM modx_session;
+```
+
+Use your real table prefix if it is not `modx_`.
+
+### Fix it: enable PHP session GC
+
+Prefer a lasting php.ini (or pool) change so every request sees the same values:
+
+```ini
+session.gc_probability = 1
+session.gc_divisor = 100
+```
+
+`1` / `100` is a common starting point. Raise probability only if the table still grows under heavy traffic.
+
+If you cannot edit the main php.ini:
+
+- Some hosts allow `.user.ini` in the web root with the same keys.
+- Apache with `AllowOverride` may accept `php_value session.gc_probability 1` in `.htaccess`.
+- PHP-FPM: set the values in the pool config and reload PHP.
+
+Confirm with `php -i` (CLI) **and** a web `ini_get()` script. CLI and the web SAPI often load different ini files.
+
+After GC runs again, old rows drop according to [`session_gc_maxlifetime`](building-sites/settings/session_gc_maxlifetime). Align that setting with [`session_cookie_lifetime`](building-sites/settings/session_cookie_lifetime) so cookies and DB cleanup agree.
+
+### Fix it: scheduled cleanup when you cannot change ini
+
+If the host locks `session.gc_probability` at `0`, schedule your own cleanup.
+
+**Option A — cron that boots MODX and calls GC** (adjust paths):
+
+```bash
+# Daily example
+0 3 * * * php /path/to/public_html/core/components/your-tool/session-gc.php
+```
+
+A minimal CLI script that loads MODX and runs handler GC (put it outside the web root when you can; adjust paths):
+
+```php
+<?php
+define('MODX_API_MODE', true);
+require '/path/to/config.core.php';
+require MODX_CORE_PATH . 'vendor/autoload.php';
+$modx = \MODX\Revolution\modX::getInstance();
+$modx->initialize('web');
+$handler = new \MODX\Revolution\modSessionHandler($modx);
+$handler->gc(0);
+```
+
+Prefer a small Extra or a documented project script over dropping ad-hoc files in the web root.
+
+**Option B — SQL cron** for expired rows (match `session_gc_maxlifetime`, default seven days):
+
+```sql
+DELETE FROM modx_session
+WHERE access < UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL 7 DAY));
+```
+
+Run this only when you understand the lifetime you want. Wrong intervals log users out early.
+
+### Emergency: clear all sessions
+
+Manager menu **Manage → Logout All Users** truncates the session table via `modSessionHandler::flushSessions()`. Everyone is logged out, including you. Use this when the table is already huge and you need space now. Then enable GC or a cron so it does not fill again.
+
+You can also `TRUNCATE TABLE modx_session;` in SQL with the same effect.
+
+### Installer check
+
+New installs run `_checkSessionsGarbageCollector()`. If probability is `0`, Setup tries `ini_set('session.gc_probability', 1)` for the setup process and shows a warning with the current probability and divisor. A successful `ini_set` during Setup does **not** permanently fix the server. You still need php.ini, pool config, or a cron for production.
+
+### Related settings
+
+| Setting | Role |
+| --- | --- |
+| [`session_handler_class`](building-sites/settings/session_handler_class) | Default `MODX\Revolution\modSessionHandler` stores sessions in the DB. Empty uses PHP’s default (often files). |
+| [`session_gc_maxlifetime`](building-sites/settings/session_gc_maxlifetime) | Age in seconds before GC deletes a session row. Default `604800`. |
+| [`session_cookie_lifetime`](building-sites/settings/session_cookie_lifetime) | Browser cookie lifetime. Keep in mind next to GC max lifetime. |
+| [`session_enabled`](building-sites/settings/session_enabled) / [`anonymous_sessions`](building-sites/settings/anonymous_sessions) | When sessions start for front-end traffic. |
+
+### See also
+
+- [PHP session.gc_probability](https://www.php.net/manual/en/session.configuration.php#ini.session.gc-probability)
+- [modxcms/revolution#16275](https://github.com/modxcms/revolution/issues/16275)
+- [Hardening MODX Revolution](getting-started/maintenance/securing-modx)

--- a/ru/building-sites/settings/session_gc_maxlifetime.md
+++ b/ru/building-sites/settings/session_gc_maxlifetime.md
@@ -1,12 +1,14 @@
 ---
 title: "session_gc_maxlifetime"
 translation: "building-sites/settings/session_gc_maxlifetime"
-description: "Позволяет настраивать ini-параметр PHP session.gc_maxlifetime при использовании modSessionHandler"
+description: "Максимальный возраст сессий в БД до удаления сборщиком мусора modSessionHandler"
 ---
 
--   **Имя**: Максимальное время жизни сборщика мусора для сессии   
--   **Тип**: String  
--   **По умолчанию**: 604800  
--   **Доступен в**: Revolution 2.1.1+
+- **Имя**: Максимальное время жизни сборщика мусора для сессии  
+- **Тип**: String  
+- **По умолчанию**: 604800  
+- **Доступен в**: Revolution 2.1.1+
 
-Позволяет настраивать ini-параметр PHP `session.gc_maxlifetime` при использовании `modSessionHandler`. 
+Возраст в секундах, после которого [`modSessionHandler`](building-sites/settings/session_handler_class) может удалить строку сессии во время PHP session garbage collection. Значение по умолчанию `604800` — семь дней. При старте сессии MODX также выставляет это значение в ini `session.gc_maxlifetime`.
+
+GC срабатывает только если позволяют `session.gc_probability` / `session.gc_divisor`. На многих хостах Debian/Ubuntu вероятность равна `0`, и настройка не работает, пока не поправите сервер или не добавите cron. См. [Сборка мусора сессий](getting-started/maintenance/session-garbage-collection).

--- a/ru/getting-started/maintenance.md
+++ b/ru/getting-started/maintenance.md
@@ -12,3 +12,4 @@ translation: "getting-started/maintenance"
 1. [Усиление безопасности / "закалка" вашего MODX сайта](getting-started/maintenance/securing-modx.md)
 2. [Перенос MODX сайта с одного сервера на другой](getting-started/maintenance/moving-your-site.md)
 3. [Обновление MODX сайта](getting-started/maintenance/upgrading.md)
+4. [Сборка мусора сессий](getting-started/maintenance/session-garbage-collection) (чтобы таблица `modx_session` не росла без предела)

--- a/ru/getting-started/maintenance/session-garbage-collection.md
+++ b/ru/getting-started/maintenance/session-garbage-collection.md
@@ -1,0 +1,135 @@
+---
+title: "Сборка мусора сессий"
+translation: "getting-started/maintenance/session-garbage-collection"
+description: "Почему растёт таблица modx_session, как PHP session GC работает с modSessionHandler и как чистить просроченные сессии"
+---
+
+## Сборка мусора сессий
+
+По умолчанию Revolution хранит сессии в базе через [`MODX\Revolution\modSessionHandler`](building-sites/settings/session_handler_class) (таблица `{table_prefix}session`, часто `modx_session`). PHP должен вызывать сборку мусора (GC) у этого обработчика. Иначе просроченные строки остаются навсегда.
+
+На многих хостингах, особенно Debian и Ubuntu, `session.gc_probability` равен `0`: ОС чистит **файловые** сессии своим cron. Этот cron **не** трогает таблицу сессий MODX. По данным SiteDash около 2021 года примерно у трёх из десяти сайтов на MODX GC не работал. Таблицы на несколько гигабайт и падение сайта — известный исход ([modxcms/revolution#16275](https://github.com/modxcms/revolution/issues/16275)).
+
+В текущих релизах Setup предупреждает, если вероятность GC равна нулю ([modxcms/revolution#16448](https://github.com/modxcms/revolution/pull/16448)). Уже установленные сайты всё равно нужно проверить вручную.
+
+### Как запускается GC
+
+На части запросов PHP вызывает метод `gc()` у обработчика сессий. Вероятность:
+
+`session.gc_probability` / `session.gc_divisor`
+
+Пример: `1` / `100` — примерно 1% запросов запускает GC.
+
+`modSessionHandler::gc()` удаляет строки сессий, у которых `access` старше [`session_gc_maxlifetime`](building-sites/settings/session_gc_maxlifetime) секунд. По умолчанию `604800` (семь дней). Эта настройка также задаёт `session.gc_maxlifetime` при старте сессии в MODX.
+
+Если `session.gc_probability` равен `0`, `gc()` не вызывается. Новые визиты добавляют строки. Таблица только растёт.
+
+### Проверка сервера
+
+В SSH или одноразовом PHP-скрипте:
+
+```bash
+php -i | grep -E 'session.gc_probability|session.gc_divisor|session.gc_maxlifetime'
+```
+
+Или временный PHP-файл:
+
+```php
+<?php
+header('Content-Type: text/plain');
+foreach (['session.gc_probability', 'session.gc_divisor', 'session.gc_maxlifetime'] as $key) {
+    echo $key, '=', ini_get($key), PHP_EOL;
+}
+```
+
+После просмотра значений файл удалите.
+
+В MySQL смотрите размер и число строк:
+
+```sql
+SHOW TABLE STATUS LIKE 'modx_session';
+SELECT COUNT(*) FROM modx_session;
+```
+
+Подставьте свой префикс таблиц, если это не `modx_`.
+
+### Исправление: включить PHP session GC
+
+Лучше закрепить значения в php.ini (или в pool PHP-FPM), чтобы их видел каждый запрос:
+
+```ini
+session.gc_probability = 1
+session.gc_divisor = 100
+```
+
+`1` / `100` — нормальная отправная точка. Поднимайте вероятность, только если таблица всё ещё растёт при высокой нагрузке.
+
+Если основной php.ini недоступен:
+
+- часть хостингов допускает `.user.ini` в корне сайта с теми же ключами;
+- Apache с `AllowOverride` может принять `php_value session.gc_probability 1` в `.htaccess`;
+- PHP-FPM: задайте значения в конфиге pool и перезагрузите PHP.
+
+Проверьте и `php -i` (CLI), и веб-скрипт с `ini_get()`. У CLI и веб-SAPI часто разные ini.
+
+Когда GC снова работает, старые строки уходят по [`session_gc_maxlifetime`](building-sites/settings/session_gc_maxlifetime). Согласуйте эту настройку с [`session_cookie_lifetime`](building-sites/settings/session_cookie_lifetime), чтобы cookie и очистка в БД жили рядом.
+
+### Исправление: cron, если ini менять нельзя
+
+Если хостинг держит `session.gc_probability` на `0`, поставьте свою очистку по расписанию.
+
+**Вариант A — cron, который поднимает MODX и вызывает GC** (пути поправьте):
+
+```bash
+# Пример: раз в сутки
+0 3 * * * php /path/to/public_html/core/components/your-tool/session-gc.php
+```
+
+Минимальный CLI-скрипт, который поднимает MODX и вызывает GC обработчика (по возможности держите вне веб-корня; пути поправьте):
+
+```php
+<?php
+define('MODX_API_MODE', true);
+require '/path/to/config.core.php';
+require MODX_CORE_PATH . 'vendor/autoload.php';
+$modx = \MODX\Revolution\modX::getInstance();
+$modx->initialize('web');
+$handler = new \MODX\Revolution\modSessionHandler($modx);
+$handler->gc(0);
+```
+
+Лучше небольшой Extra или скрипт проекта, чем случайный файл в веб-корне.
+
+**Вариант B — SQL по cron** для просроченных строк (срок как у `session_gc_maxlifetime`, по умолчанию семь дней):
+
+```sql
+DELETE FROM modx_session
+WHERE access < UNIX_TIMESTAMP(DATE_SUB(NOW(), INTERVAL 7 DAY));
+```
+
+Запускайте только если понимаете нужный срок жизни. Слишком короткий интервал выкинет пользователей раньше времени.
+
+### Аварийно: очистить все сессии
+
+В Менеджере пункт **Управление → Завершить все сеансы** очищает таблицу через `modSessionHandler::flushSessions()`. Выходят все, включая вас. Так делают, когда таблица уже огромная и нужно место сейчас. Затем включите GC или cron, иначе она снова заполнится.
+
+Тот же эффект даёт `TRUNCATE TABLE modx_session;` в SQL.
+
+### Проверка в установщике
+
+Новые установки вызывают `_checkSessionsGarbageCollector()`. При вероятности `0` Setup пробует `ini_set('session.gc_probability', 1)` на время установки и показывает предупреждение с текущими probability и divisor. Удачный `ini_set` в Setup **не** чинит сервер навсегда. Для боя нужны php.ini, pool или cron.
+
+### Связанные настройки
+
+| Настройка | Назначение |
+| --- | --- |
+| [`session_handler_class`](building-sites/settings/session_handler_class) | По умолчанию `MODX\Revolution\modSessionHandler` пишет сессии в БД. Пустое значение — стандартный обработчик PHP (часто файлы). |
+| [`session_gc_maxlifetime`](building-sites/settings/session_gc_maxlifetime) | Возраст в секундах, после которого GC удаляет строку. По умолчанию `604800`. |
+| [`session_cookie_lifetime`](building-sites/settings/session_cookie_lifetime) | Время жизни cookie в браузере. Смотрите рядом с max lifetime GC. |
+| [`session_enabled`](building-sites/settings/session_enabled) / [`anonymous_sessions`](building-sites/settings/anonymous_sessions) | Когда на фронтенде стартуют сессии. |
+
+### Смотрите также
+
+- [PHP session.gc_probability](https://www.php.net/manual/ru/session.configuration.php#ini.session.gc-probability)
+- [modxcms/revolution#16275](https://github.com/modxcms/revolution/issues/16275)
+- [Усиление безопасности MODX Revolution](getting-started/maintenance/securing-modx)


### PR DESCRIPTION
## Description

Many MODX sites never run PHP session garbage collection. Default DB sessions (`modSessionHandler` → `{prefix}session`) then grow without bound. Debian/Ubuntu often set `session.gc_probability = 0` because a system cron cleans **file** sessions, which does not touch the MODX table.

This adds a maintenance guide (English and Russian) that covers:

- what session GC is and why MODX needs it
- how `gc_probability` / `gc_divisor` and `session_gc_maxlifetime` interact with `modSessionHandler::gc()`
- how to check ini values and table size
- fixes: php.ini / FPM / `.user.ini`, cron + API script or SQL delete, emergency Flush Sessions (`Manage → Logout All Users`)
- what the Setup warning from [modxcms/revolution#16448](https://github.com/modxcms/revolution/pull/16448) means (and that `ini_set` during install is not permanent)

Also links the page from Maintenance indexes and expands the short `session_gc_maxlifetime` setting pages.

Checked against Revolution 3.x `modSessionHandler`, Setup `_checkSessionsGarbageCollector()`, and related system settings.

## Affected versions

3.x docs. Behavior applies to Revolution 2.x/3.x sites that use database sessions.

## Relevant issues

Fixes https://github.com/modxorg/Docs/issues/423

Related: https://github.com/modxcms/revolution/issues/16275 · https://github.com/modxcms/revolution/pull/16448