### PR TITLE
docs(events): fix OnBeforeDocFormSave save() guidance (en, ru)

### DIFF
--- a/en/extending-modx/plugins/system-events/onbeforedocformsave.md
+++ b/en/extending-modx/plugins/system-events/onbeforedocformsave.md
@@ -2,63 +2,74 @@
 title: "OnBeforeDocFormSave"
 _old_id: "381"
 _old_uri: "2.x/developing-in-modx/basic-development/plugins/system-events/onbeforedocformsave"
+description: "Plugin event fired before the Manager Resource create/update processor saves the resource"
 ---
 
 ## Event: OnBeforeDocFormSave
 
-Fires before a Resource is saved in the manager via the editing form. This allows code to prevent the saving of a document.
+Fires in the Manager **before** the Resource create or update processor persists the Resource. Use it to change fields on the `$resource` object, or to block the save.
 
 - Service: 1 - Parser Service Events
 - Group: Documents
 
-**Be Careful with TVs**
-Changing or inserting TV values is better done [OnDocFormSave](extending-modx/plugins/system-events/ondocformsave "OnDocFormSave") as the process for saving TVs during onBeforeDocFormSave is more complicated due to TV values being rendered.
+Fired from `MODX\Revolution\Processors\Resource\Create` and `Update` (also `UpdateFromGrid`). Flow in those processors:
 
-Plugins tied to this event should return **null** on success. Any value returned will be sent to the logs as an error (but the page will still be saved).
+1. Fields are applied to the Resource object
+2. `OnBeforeDocFormSave` runs
+3. The processor calls `$resource->save()`
+4. After-save work runs (TVs on update, resource groups, and so on)
+5. `OnDocFormSave` runs
 
-You may also pass a message to the `$modx->event->output()` function and this will be displayed to the user in a modal pop-up window. If you pass a value here, **the page will _not_ be saved!**
+### Changing fields vs calling `save()`
 
-**Text Only**
- If you pass a value to the `$modx->event->output()`, it must be text only! HTML tags are not allowed: they will cause the modal window to hang.
+For Resource fields, call `$resource->set(...)`. You do **not** need `$resource->save()` in the plugin. The processor saves after your plugin returns.
+
+Do **not** call `$resource->save()` here unless you have a rare reason to persist early. An early `save()` can write the row before Template Variables and related after-save steps run, and it muddies create vs update timing. Prefer [OnDocFormSave](extending-modx/plugins/system-events/ondocformsave) for TV changes (`setTVValue`).
+
+### Blocking the save
+
+Plugins should return nothing (or an empty value) on success. A non-empty return value is treated as an error message and is logged; depending on how it is returned it may still allow the save to continue.
+
+To **stop** the save and show a message in the Manager, pass text to `$modx->event->output(...)`. That text must be plain text (no HTML), or the modal can hang.
 
 ## Event Parameters
 
-| Name     | Description                                            |
-| -------- | ------------------------------------------------------ |
-| mode     | Either 'new' or 'upd', depending on the circumstances. |
-| resource | A reference to the modResource object.                 |
-| id       | The ID of the Resource. Will be 0 for new Resources.   |
+| Name | Description |
+| --- | --- |
+| mode | `new` or `upd` (`modSystemEvent::MODE_NEW` / `MODE_UPD`) |
+| resource | Reference to the `modResource` object (passed by reference) |
+| id | Resource ID. `0` for new Resources that are not saved yet |
 
 ## Examples
 
-### Require a Field
+### Require a field
 
 ``` php
-if (empty($resource->longtitle)) {
-    $modx->event->output('Long title is required!'); // to modal window
-    return '[MyPlugin] Failed to save page id '.$id.' due to missing longtitle'; // to the error log
+if (empty($resource->get('longtitle'))) {
+    $modx->event->output('Long title is required!');
+    return;
 }
 ```
 
-### Calculate a Field Value
+### Set a field before the processor saves
 
 ``` php
-if ($resource->get('parent') == 123) {
+if ((int) $resource->get('parent') === 123) {
     $resource->set('template', 4);
 }
 ```
 
-Such a plugin will not allow the creation of new resources, and will not save resources that are not filled `introtext`:
+No `$resource->save()` here. The create/update processor saves next.
+
+### Block create, or updates missing introtext
 
 ``` php
 <?php
-$eventName = $modx->event->name;
-switch($eventName) {
+switch ($modx->event->name) {
     case 'OnBeforeDocFormSave':
         if ($mode == modSystemEvent::MODE_UPD) {
-            //if not filled introtext
-            if (!$resource->get('introtext')){
-                $modx->event->output("You have not forgotten your head at home, but you have forgotten about the 'Keywords'!");
+            if (!$resource->get('introtext')) {
+                $modx->event->output("Please fill in the Intro Text field.");
             }
         } elseif ($mode == modSystemEvent::MODE_NEW) {
             $modx->event->output("You cannot create resources!");
@@ -67,25 +78,21 @@ switch($eventName) {
 }
 ```
 
-Such a plugin will set the value of the field `template=1` for all resources located in the root, i.e. `parent=0`:
+### Force a template for root resources
 
 ``` php
 <?php
-$eventName = $modx->event->name;
-switch($eventName) {
+switch ($modx->event->name) {
     case 'OnBeforeDocFormSave':
-        if ($resource->get('parent') == 0) {
-            $resource->set('template', '1');
-            $resource->save();
+        if ((int) $resource->get('parent') === 0) {
+            $resource->set('template', 1);
         }
         break;
 }
 ```
 
-**Saving Not! Happens Automatically**
-You should run the `$resource->save()` method additionally, as that doesn't happen automatically.
-
 ## See Also
 
-- [System Events](extending-modx/plugins/system-events "System Events")
-- [Plugins](extending-modx/plugins "Plugins")
+- [OnDocFormSave](extending-modx/plugins/system-events/ondocformsave)
+- [System Events](extending-modx/plugins/system-events)
+- [Plugins](extending-modx/plugins)

--- a/ru/extending-modx/plugins/system-events/onbeforedocformsave.md
+++ b/ru/extending-modx/plugins/system-events/onbeforedocformsave.md
@@ -1,63 +1,74 @@
 ---
 title: "OnBeforeDocFormSave"
 translation: "extending-modx/plugins/system-events/onbeforedocformsave"
+description: "Событие плагина до сохранения ресурса процессором создания/обновления в Менеджере"
 ---
 
 ## Событие: OnBeforeDocFormSave
 
-Запускается до сохранения ресурса в менеджере через форму редактирования. Это позволяет коду предотвращать сохранение документа.
+Срабатывает в Менеджере **до** того, как процессор создания или обновления ресурса запишет его в БД. Здесь меняют поля объекта `$resource` или блокируют сохранение.
 
-Служба: 1 - Parser Service Events
-Группа: Documents
+- Служба: 1 - Parser Service Events
+- Группа: Documents
 
-**Будь осторожен с TVs**
-Изменение или вставка значений TV лучше сделать [OnDocFormSave](extending-modx/plugins/system-events/ondocformsave "OnDocFormSave") поскольку процесс сохранения TV во время onBeforeDocFormSave более сложен из-за визуализации значений TV.
+Вызывается из `MODX\Revolution\Processors\Resource\Create` и `Update` (также `UpdateFromGrid`). Порядок в этих процессорах:
 
-Плагины, привязанные к этому событию, должны вернуть **null** в случае успеха. Любое возвращенное значение будет отправлено в журналы как ошибка (но страница все равно будет сохранена).
+1. Поля попадают в объект Resource
+2. Выполняется `OnBeforeDocFormSave`
+3. Процессор вызывает `$resource->save()`
+4. Идёт работа после сохранения (TV при update, группы ресурсов и т. д.)
+5. Выполняется `OnDocFormSave`
 
-Вы также можете передать сообщение в функцию `$modx->event->output()`, и оно будет отображено пользователю во всплывающем модальном окне. Если вы передаете значение здесь, **страница _не_ будет сохранена!**
+### Изменение полей и вызов `save()`
 
-**Только текст**
- Если вы передаете значение в `$modx->event->output()`, оно должно быть только текстовым! HTML-теги не допускаются: они приводят к зависанию модального окна.
+Для полей ресурса вызывайте `$resource->set(...)`. В плагине **не** нужен `$resource->save()`: процессор сохранит объект после возврата из плагина.
+
+Не вызывайте `$resource->save()` здесь без веской причины. Ранний `save()` может записать строку до Template Variables и прочих шагов after-save и путает момент create/update. Для TV лучше [OnDocFormSave](extending-modx/plugins/system-events/ondocformsave) и `setTVValue`.
+
+### Блокировка сохранения
+
+При успехе плагин ничего не возвращает (или возвращает пустое значение). Непустое возвращаемое значение попадает в лог как ошибка. В зависимости от формы возврата сохранение при этом всё ещё может пройти.
+
+Чтобы **остановить** сохранение и показать сообщение в Менеджере, передайте текст в `$modx->event->output(...)`. Только plain text (без HTML), иначе модальное окно может зависнуть.
 
 ## Параметры события
 
-| Имя      | Описание                                               |
-| -------- | ------------------------------------------------------ |
-| mode     | Либо 'new' либо 'upd', в зависимости от обстоятельств. |
-| resource | Ссылка на объект modResource.                          |
-| id       | Идентификатор ресурса. Будет 0 для новых ресурсов.     |
+| Имя | Описание |
+| --- | --- |
+| mode | `new` или `upd` (`modSystemEvent::MODE_NEW` / `MODE_UPD`) |
+| resource | Ссылка на объект `modResource` (передаётся по ссылке) |
+| id | ID ресурса. Для ещё не сохранённых новых ресурсов — `0` |
 
 ## Примеры
 
-### Требуемые поля
+### Обязательное поле
 
 ``` php
-if (empty($resource->longtitle)) {
-    $modx->event->output('Требуется расширенное название!'); // to modal window
-    return '[MyPlugin] Не удалось сохранить id страницы '.$id.' из-за отсутствия длинного заголовка'; // в журнал ошибок
+if (empty($resource->get('longtitle'))) {
+    $modx->event->output('Нужен расширенный заголовок!');
+    return;
 }
 ```
 
-### Рассчитать значение поля
+### Задать поле до сохранения процессором
 
 ``` php
-if ($resource->get('parent') == 123) {
+if ((int) $resource->get('parent') === 123) {
     $resource->set('template', 4);
 }
 ```
 
-Такой плагин не разрешит создавать новые ресурсы, и не будет сохранять ресурсы, у которых не заполнено `introtext`:
+Здесь `$resource->save()` не вызывайте. Дальше сохранит процессор create/update.
+
+### Запрет создания или обновления без introtext
 
 ``` php
 <?php
-$eventName = $modx->event->name;
-switch($eventName) {
+switch ($modx->event->name) {
     case 'OnBeforeDocFormSave':
         if ($mode == modSystemEvent::MODE_UPD) {
-            //если не заполнен introtext
-            if (!$resource->get('introtext')){
-                $modx->event->output("Голову ты дома не забыл, а про 'Ключевые слова' забыл!");
+            if (!$resource->get('introtext')) {
+                $modx->event->output("Заполните поле «Аннотация» (introtext).");
             }
         } elseif ($mode == modSystemEvent::MODE_NEW) {
             $modx->event->output("Вам нельзя создавать ресурсы!");
@@ -66,25 +77,21 @@ switch($eventName) {
 }
 ```
 
-Такой плагин установит значение поля `template=1` у всех ресурсов находящийхся в корне т.е `parent=0`:
+### Шаблон для ресурсов в корне
 
 ``` php
 <?php
-$eventName = $modx->event->name;
-switch($eventName) {
+switch ($modx->event->name) {
     case 'OnBeforeDocFormSave':
-        if ($resource->get('parent') == 0) {
-            $resource->set('template', '1');
-            $resource->save();
+        if ((int) $resource->get('parent') === 0) {
+            $resource->set('template', 1);
         }
         break;
 }
 ```
 
-**Принудительное сохранение**
-Также необходимо запустить  `$resource->save()` метод, так как это не происходит автоматически.
+## Смотрите также
 
-## Смотри также
-
-- [Системные события](extending-modx/plugins/system-events "Системные события")
-- [Плагины](extending-modx/plugins "Плагины")
+- [OnDocFormSave](extending-modx/plugins/system-events/ondocformsave)
+- [Системные события](extending-modx/plugins/system-events)
+- [Плагины](extending-modx/plugins)


### PR DESCRIPTION
## Description

Issue #244 objected to “Saving Happens Automatically / no need to call `$resource->save()`”. A later docs change (#329) flipped that to “you must call `save()`”, which does not match Revolution’s Resource processors.

In 3.x, `CreateProcessor` / `UpdateProcessor` run `fireBeforeSaveEvent()` (`OnBeforeDocFormSave`) and **then** `saveObject()` (`$resource->save()`). Field changes via `$resource->set()` are persisted by that processor save. Calling `save()` inside the plugin is usually harmful (early persist before TV / after-save steps).

This updates EN and RU pages to document that order, restore “no `save()` needed for field sets”, warn against early `save()`, and clean up examples.

Checked against `Processors\Model\CreateProcessor::process()`, `UpdateProcessor::process()`, and `Processors\Resource\Create::fireBeforeSaveEvent()`.

## Affected versions

3.x docs. Same processor order applies on modern 2.x Resource create/update processors.

## Relevant issues

Fixes https://github.com/modxorg/Docs/issues/244