### PR TITLE
docs(formit): Add mail/SMTP troubleshooting for contact forms

### DIFF
--- a/en/building-sites/sending-mail/amazon-ses.md
+++ b/en/building-sites/sending-mail/amazon-ses.md
@@ -18,7 +18,7 @@ Still in the Amazon SES dashboard, go to Email Sending > SMTP Settings.
 
 - You'll see the server name listed; add that to the `mail_smtp_hosts` system setting.
 - Use one of the provided ports for the `mail_smtp_port` system setting. Any of them should work, typically 465 or 587.
-- As it indicates TLS is enabled, set `mail_smtp_prefix` to `tls` (or `ssl`). 
+- As it indicates TLS is enabled, set `mail_smtp_secure` to `tls` or `ssl` (MODX 3 Mail settings). 
 
 Next, click the "Create My SMTP Credentials" button. That's a convenient shortcut to adding an IAM user, which otherwise is a fairly complex process.
 

--- a/en/building-sites/sending-mail/index.md
+++ b/en/building-sites/sending-mail/index.md
@@ -18,10 +18,10 @@ By default, email is sent using PHPs `mail()` feature. This uses server-level se
 
 1. Enable the `mail_use_smtp` system setting
 2. Enable the `mail_smtp_auth` system setting
-3. Configure the host the SMTP server is available from in the `mail_smtp_hosts` system setting. 
+3. Configure the host the SMTP server is available from in the `mail_smtp_hosts` system setting.
 4. Configure the SMTP port in the `mail_smtp_port` system setting. In many cases, port 25 is blocked, so you'll need to use a different one, typically 587 or 465.
 5. Enter your SMTP credentials in the `mail_smtp_user` and `mail_smtp_pass` fields.
-6. If necessary, set the `mail_smtp_prefix` to `tls` or `ssl`. 
+6. If necessary, set `mail_smtp_secure` to `tls` or `ssl` (MODX 3). Older docs referred to `mail_smtp_prefix`; use the Mail area in System Settings and match what your install shows.
 
 For steps 3-6, the exact details will depend on the mail server or mail service you're using. Consult their documentation, setup instructions, or support for the information to use.
 
@@ -29,6 +29,23 @@ More specific instructions are available for:
 
 - [Amazon SES](building-sites/sending-mail/amazon-ses)
 - [Mailtrap.io](building-sites/sending-mail/mailtrap)
+
+### Common SMTP providers
+
+Use these as starting points. Providers change auth rules; create app passwords or SMTP credentials in their dashboards when prompted.
+
+| Provider | Host | Port | `mail_smtp_secure` | Auth notes |
+| -------- | ---- | ---- | ------------------ | ---------- |
+| Gmail / Google Workspace | `smtp.gmail.com` | `587` / `465` | `tls` / `ssl` | App password or OAuth; plain account password usually rejected |
+| Yandex Mail | `smtp.yandex.com` or `smtp.yandex.ru` | `465` / `587` | `ssl` on 465 | App password from Yandex Mail client settings |
+| Mail.ru | `smtp.mail.ru` | `465` / `587` | `ssl` / `tls` | App password from Mail.ru security settings |
+| Rambler | `smtp.rambler.ru` | `465` | `ssl` | Confirm current requirements in Rambler help |
+| Mailgun | `smtp.mailgun.org` or `smtp.eu.mailgun.org` | `587` / `465` / `2525` | Match port | Per-domain SMTP credentials in Mailgun |
+| Custom VPS / shared hosting | Host-provided SMTP hostname | Often `587` or `465` | Per host | Outbound `25` is often blocked |
+
+Set `emailsender` to an address that provider allows (same mailbox, or a verified sending domain).
+
+If FormIt redirects or shows success but no message arrives, install [QuickEmail](extras/quickemail) and test SMTP alone before changing FormIt hooks. See also the troubleshooting section on the [simple contact page](extras/formit/formit.tutorials-and-examples/examples.simple-contact-page).
 
 ## Testing email sending
 

--- a/en/extras/formit/formit.tutorials-and-examples/examples.simple-contact-page.md
+++ b/en/extras/formit/formit.tutorials-and-examples/examples.simple-contact-page.md
@@ -117,8 +117,56 @@ This is the FormIt Email Chunk.
 [[+text]]
 ```
 
+## Form submits but no email arrives
+
+FormIt uses MODX’s mail settings. If the form “works” (redirect, success message) but the inbox stays empty, treat it as a mail/SMTP problem first.
+
+### 1. Confirm FormIt itself is fine
+
+1. Check validation and hook errors on the page: `[[!+fi.error_message]]`, `[[!+fi.validation_error_message]]`, and field errors such as `[[!+fi.error.email]]`.
+2. Keep `&hooks=` order sensible: validation-related hooks (for example `recaptcha`) before `email`, then `redirect` last. If `email` fails, later hooks may not run as you expect.
+3. Set `&emailTo=` to an address you can open right now.
+4. Keep `&emailFrom=` as `[[++emailsender]]` (or another address on a domain you control). Do not use the visitor’s address as `From`.
+5. Confirm the `emailTpl` chunk exists and renders. Wrong chunk names fail the email hook silently from the visitor’s point of view.
+
+### 2. Separate FormIt from SMTP with QuickEmail
+
+Install [QuickEmail](extras/quickemail) (Bob Ray) from Package Management. On a temporary Resource, put:
+
+``` php
+[[!QuickEmail? &debug=`1`]]
+```
+
+Preview that Resource. QuickEmail sends a test message through the same MODX mail stack FormIt uses and prints a debug log.
+
+- If QuickEmail fails, fix System Settings under **System → System Settings → area Mail** before you chase FormIt hooks.
+- If QuickEmail succeeds and FormIt still does not, re-check `&emailTo`, `&emailTpl`, hooks, and spam folders.
+
+Remove the QuickEmail call when you finish. Leaving `&debug=` on a public page can expose mail configuration details.
+
+Full SMTP setup, deliverability notes, and provider examples: [Sending mail](building-sites/sending-mail).
+
+### 3. Typical SMTP settings (MODX 3)
+
+Enable `mail_use_smtp` and usually `mail_smtp_auth`. Set host, port, user, password, and encryption (`mail_smtp_secure`: `tls` or `ssl`, or leave empty and rely on `mail_smtp_autotls` when appropriate).
+
+| Provider | `mail_smtp_hosts` | Port | Secure | Notes |
+| -------- | ----------------- | ---- | ------ | ----- |
+| Gmail / Google Workspace | `smtp.gmail.com` | `587` or `465` | `tls` (587) or `ssl` (465) | Use an [app password](https://support.google.com/accounts/answer/185833) or OAuth-capable setup. Account password alone usually fails. |
+| Yandex Mail | `smtp.yandex.com` (or `smtp.yandex.ru`) | `465` or `587` | `ssl` (465) | Create an app password in Yandex Mail client settings. |
+| Mail.ru | `smtp.mail.ru` | `465` or `587` | `ssl` / `tls` | Use an app password from Mail.ru security settings. |
+| Rambler | `smtp.rambler.ru` | `465` | `ssl` | Confirm current values in Rambler help; they change with account security rules. |
+| Mailgun | `smtp.mailgun.org` (EU: `smtp.eu.mailgun.org`) | `587`, `465`, or `2525` | `tls` / `ssl` as required by port | SMTP user/password come from the Mailgun domain’s SMTP credentials. |
+| Custom VPS / hosting | Your host’s SMTP hostname | Often `587` or `465` | Per host docs | Many hosts block outbound port `25`. Prefer authenticated submission on 587/465. |
+
+Also set `emailsender` to an address allowed by that provider (verified domain for Mailgun/SES, or the mailbox you authenticate as for consumer SMTP).
+
+Community thread that prompted this section: [Can’t get FormIt to send form](https://community.modx.com/t/cant-get-formit-to-send-form/3736).
+
 ## See Also
 
-1. [FormIt.Hooks.recaptcha](extras/formit/formit.hooks/recaptcha)
-2. [FormItAutoResponder](extras/formit/formit.hooks/formitautoresponder)
-3. [FormIt.Validators](extras/formit/formit.validators)
+1. [Sending mail](building-sites/sending-mail)
+2. [QuickEmail](extras/quickemail)
+3. [FormIt.Hooks.recaptcha](extras/formit/formit.hooks/recaptcha)
+4. [FormItAutoResponder](extras/formit/formit.hooks/formitautoresponder)
+5. [FormIt.Validators](extras/formit/formit.validators)

--- a/ru/extras/formit/formit.tutorials-and-examples/examples.simple-contact-page.md
+++ b/ru/extras/formit/formit.tutorials-and-examples/examples.simple-contact-page.md
@@ -117,8 +117,56 @@ description: "Пример простой контактной формы свя
 [[+text]]
 ```
 
+## Форма уходит, а письма нет
+
+FormIt шлёт почту через системные настройки MODX. Если форма «срабатывает» (редирект, success), а письма в ящике нет, сначала проверяйте SMTP и доставку, а не только хуки FormIt.
+
+### 1. Проверьте сам FormIt
+
+1. Смотрите ошибки на странице: `[[!+fi.error_message]]`, `[[!+fi.validation_error_message]]` и ошибки полей вроде `[[!+fi.error.email]]`.
+2. Держите порядок `&hooks=` осмысленным: проверки (например `recaptcha`) до `email`, `redirect` в конце. Если `email` падает, следующие хуки могут не отработать так, как вы ждёте.
+3. Укажите в `&emailTo=` адрес, который вы реально читаете.
+4. Оставьте `&emailFrom=` как `[[++emailsender]]` (или другой адрес вашего домена). Не ставьте email посетителя в `From`.
+5. Убедитесь, что чанк `emailTpl` существует и рендерится. Неверное имя чанка ломает email-хук без явной ошибки для посетителя.
+
+### 2. Отделите FormIt от SMTP через QuickEmail
+
+Установите [QuickEmail](extras/quickemail) (Bob Ray) через Управление пакетами. На временном ресурсе поставьте:
+
+```php
+[[!QuickEmail? &debug=`1`]]
+```
+
+Откройте ресурс на сайте. QuickEmail отправит тестовое письмо тем же стеком MODX, что и FormIt, и выведет подробный лог.
+
+- Если QuickEmail не шлёт письмо, сначала поправьте **Система → Системные настройки → область Mail**.
+- Если QuickEmail работает, а FormIt нет, снова проверьте `&emailTo`, `&emailTpl`, хуки и папку «Спам».
+
+Уберите вызов QuickEmail после проверки. Публичная страница с `&debug=` может светить параметры почты.
+
+Полная настройка SMTP, доставляемость и примеры провайдеров: [Sending mail](building-sites/sending-mail) (EN). Ключи настроек те же в русской панели.
+
+### 3. Типичные SMTP-настройки (MODX 3)
+
+Включите `mail_use_smtp` и обычно `mail_smtp_auth`. Задайте хост, порт, логин, пароль и шифрование (`mail_smtp_secure`: `tls` или `ssl`, либо пустое значение плюс `mail_smtp_autotls`, если так удобнее провайдеру).
+
+| Провайдер | `mail_smtp_hosts` | Порт | Secure | Заметки |
+| --------- | ----------------- | ---- | ------ | ------- |
+| Gmail / Google Workspace | `smtp.gmail.com` | `587` или `465` | `tls` (587) или `ssl` (465) | Нужен [пароль приложения](https://support.google.com/accounts/answer/185833) или OAuth. Обычный пароль аккаунта чаще всего не проходит. |
+| Яндекс Почта | `smtp.yandex.ru` (или `smtp.yandex.com`) | `465` или `587` | `ssl` (465) | Создайте пароль приложения в настройках почтовых клиентов Яндекса. |
+| Mail.ru | `smtp.mail.ru` | `465` или `587` | `ssl` / `tls` | Пароль приложения из настроек безопасности Mail.ru. |
+| Rambler | `smtp.rambler.ru` | `465` | `ssl` | Актуальные значения смотрите в справке Rambler. Правила доступа меняются. |
+| Mailgun | `smtp.mailgun.org` (EU: `smtp.eu.mailgun.org`) | `587`, `465` или `2525` | `tls` / `ssl` по порту | Логин и пароль SMTP берутся в credentials домена в Mailgun. |
+| Свой VPS / хостинг | SMTP-хост от провайдера | Часто `587` или `465` | По документации хоста | Исходящий порт `25` часто закрыт. Используйте авторизованную отправку на 587/465. |
+
+Значение `emailsender` должно быть адресом, который провайдер разрешает (верифицированный домен для Mailgun/SES или ящик, под которым вы логинитесь в SMTP).
+
+Тема на форуме, которая привела к этому разделу: [Can’t get FormIt to send form](https://community.modx.com/t/cant-get-formit-to-send-form/3736).
+
 ## Смотрите также
 
-1. [FormIt.Hooks.recaptcha](extras/formit/formit.hooks/recaptcha)
-2. [FormItAutoResponder](extras/formit/formit.hooks/formitautoresponder)
-3. [FormIt.Validators](extras/formit/formit.validators)
+1. [Sending mail](building-sites/sending-mail)
+2. [QuickEmail](extras/quickemail)
+3. [FormIt.Hooks.recaptcha](extras/formit/formit.hooks/recaptcha)
+4. [FormItAutoResponder](extras/formit/formit.hooks/formitautoresponder)
+5. [FormIt.Validators](extras/formit/formit.validators)


### PR DESCRIPTION
## Description

Adds a troubleshooting section to the FormIt simple contact page (EN + RU) for the common case where the form appears to succeed but no email arrives.

The section separates FormIt checks (`emailFrom` / `emailsender`, hooks, `emailTpl`) from SMTP diagnosis with [QuickEmail](https://modx.com/extras/package/quickemail), links to [Sending mail](https://docs.modx.com/3.x/en/building-sites/sending-mail), and lists typical host/port/secure values for Gmail, Yandex, Mail.ru, Rambler, Mailgun, and custom VPS/hosting.

Also expands the EN Sending mail guide with the same provider table and updates MODX 3 encryption setting names from legacy `mail_smtp_prefix` to `mail_smtp_secure` (verified against Revolution `3.x` system settings / lexicon).

Prompted by community reports such as [Can’t get FormIt to send form](https://community.modx.com/t/cant-get-formit-to-send-form/3736).

## Affected versions

Docs `3.x` tree. Mail setting keys match MODX Revolution 3.x (`mail_smtp_secure`, `mail_smtp_autotls`). FormIt Extra guidance applies wherever FormIt uses core mail.

## Relevant issues

Fixes #273