### PR TITLE
docs(acl): document 3.3.0 top-menu Access Policy alignment

### DIFF
--- a/en/building-sites/client-proofing/security/policies/permissions/administrator-policy.md
+++ b/en/building-sites/client-proofing/security/policies/permissions/administrator-policy.md
@@ -8,19 +8,18 @@ _old_uri: "2.x/administering-your-site/security/policies/permissions/permissions
 
 This policy is packaged into MODX and is given to users on the 'mgr' context who want to have full access to managing MODX content.
 
+From MODX 3.3.0 the top-menu keys match the pages they open. Parent folders use `menu_*` keys. See [Upgrading to 3.3.0](getting-started/maintenance/upgrading/3.3.0).
+
 ## Default Permissions
 
 | Name                        | Description of Access                                                                                                            |
 | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| about                       | The About page.                                                                                                                  |
-| access\_permissions         | Any Access Permission-related pages and actions.                                                                                 |
+| access\_permissions         | Pages under Access that use this key (Resource Groups, ACLs, Flush Permissions). The Access parent menu uses `menu_access`.       |
 | action\_ok                  |
-| actions                     | The [Actions](extending-modx/menus/actions "Actions and Menus") page.                                                            |
 | change\_password            | User can change their user password.                                                                                             |
 | change\_profile             | User can change their profile.                                                                                                   |
 | content\_types              | The [Content Types](building-sites/resources/content-types "Content Types") page.                                                |
 | create                      | Basic "create" access on objects.                                                                                                |
-| credits                     | View the Credits page.                                                                                                           |
 | customize\_forms            | View and manage the [Customizing the Manager](building-sites/client-proofing/form-customization "Customizing the Manager") page. |
 | database                    | The System Info page                                                                                                             |
 | database\_truncate          | The ability to truncate a database table.                                                                                        |
@@ -49,8 +48,8 @@ This policy is packaged into MODX and is given to users on the 'mgr' context who
 | edit\_user                  | To edit any [User](building-sites/client-proofing/security/users "Users").                                                       |
 | element\_tree               | The ability to view the Elements Tree on the left nav.                                                                           |
 | empty\_cache                | To empty the site cache.                                                                                                         |
-| export\_static              | To export the site to static HTML.                                                                                               |
-| file\_manager               | To use the file manager, including creating/deleting files.                                                                      |
+| error\_log\_view            | View the Error Log under Reports (menu, `system/event`, and ErrorLog processors).                                                |
+| file\_manager               | Use the Media Browser and related file manager actions. The Media parent menu uses `menu_media`.                                 |
 | file\_tree                  | To view the Files Tree on the left nav.                                                                                          |
 | flush\_sessions             | Can flush Sessions across the site.                                                                                              |
 | frames                      | To use the MODX Manager UI at all.                                                                                               |
@@ -61,9 +60,11 @@ This policy is packaged into MODX and is given to users on the 'mgr' context who
 | lexicons                    | To edit or view Lexicons and [Internationalization](extending-modx/internationalization "Internationalization").                 |
 | list                        | Basic permission to "list" any object. List means to get a collection of objects.                                                |
 | load                        | Basic permission to "load" any object, or be able to return it as an instance at all.                                            |
-| logout                      | To be able to logout as a user.                                                                                                  |
 | logs                        | To view the logs, such as error and manager logs.                                                                                |
-| menus                       | To edit or save any top Menu items.                                                                                              |
+| menu\_access                | Show the main menu item Access.                                                                                                  |
+| menu\_media                 | Show the main menu item Media.                                                                                                   |
+| menu\_system                | Show the main menu item Gear (System). Does not grant System Settings (`settings`).                                              |
+| menus                       | View and manage Gear → Menus (`system/action` and Menu processors).                                                              |
 | messages                    | To send or view any personal Messages.                                                                                           |
 | namespaces                  | To edit or view [Namespaces](extending-modx/namespaces "Namespaces").                                                            |
 | new\_category               | To create a new Category.                                                                                                        |
@@ -96,7 +97,7 @@ This policy is packaged into MODX and is given to users on the 'mgr' context who
 | save\_tv                    | To save any [Template Variables](building-sites/elements/template-variables "Template Variables").                               |
 | save\_user                  | To save any [User](building-sites/client-proofing/security/users "Users").                                                       |
 | search                      | To use the Search page.                                                                                                          |
-| settings                    | To view and edit any System Settings.                                                                                            |
+| settings                    | To view and edit System Settings. The Gear parent menu uses `menu_system`.                                                       |
 | steal\_locks                | To "steal" locks, overriding a current lock on a document.                                                                       |
 | unlock\_element\_properties | To be able to edit the default properties for any Element.                                                                       |
 | view                        | Basic permission to "view" any object.                                                                                           |
@@ -104,7 +105,6 @@ This policy is packaged into MODX and is given to users on the 'mgr' context who
 | view\_chunk                 | To view any [Chunks](building-sites/elements/chunks "Chunks").                                                                   |
 | view\_context               | To view any [Contexts](building-sites/contexts "Contexts").                                                                      |
 | view\_document              | To view any [Resources](building-sites/resources "Resources").                                                                   |
-| view\_eventlog              | To view the Event Log.                                                                                                           |
 | view\_offline               |
 | view\_plugin                | To view any [Plugins](extending-modx/plugins "Plugins").                                                                         |
 | view\_role                  | To view any [Roles](building-sites/client-proofing/security/roles "Roles").                                                      |
@@ -117,7 +117,7 @@ This policy is packaged into MODX and is given to users on the 'mgr' context who
 
 ## Custom Permissions
 
-If you have created your own actions and menu items (e.g. if you have created a [Custom Manager Page](extending-modx/custom-manager-pages "Custom Manager Pages Tutorial")), then you can define custom permission items when you create the menu item (System --> Actions --> Create Menu) that correspond to permissions listed here.
+If you have created your own menu items (for example a [Custom Manager Page](extending-modx/custom-manager-pages "Custom Manager Pages Tutorial")), set a permission key on the menu item (System → Menus) that matches a permission on this policy.
 
 ![](modx+custom+permission.jpg)
 

--- a/en/building-sites/client-proofing/security/policies/permissions/index.md
+++ b/en/building-sites/client-proofing/security/policies/permissions/index.md
@@ -23,6 +23,8 @@ Access Policies (ACLs) define lists of permissions (see Menu --> Access Controls
 1. [Permissions - Administrator Policy](building-sites/client-proofing/security/policies/permissions/administrator-policy)
 2. [Permissions - Resource Policy](building-sites/client-proofing/security/policies/permissions/resource-policy)
 
+From MODX 3.3.0, top-menu parent folders and some report/system items use dedicated permission keys. See [Upgrading to 3.3.0](getting-started/maintenance/upgrading/3.3.0).
+
 ## See Also
 
 1. [Users](building-sites/client-proofing/security/users)

--- a/en/getting-started/maintenance/upgrading.md
+++ b/en/getting-started/maintenance/upgrading.md
@@ -72,6 +72,7 @@ It's a good idea to clear your browser cache after upgrading. Browsers often cac
 For changes relating to specific versions, please see the following pages:
 
 - [Upgrading from 2.x to 3.0](getting-started/upgrading-to-3.0) (required reading for any 2.x → 3.x move; includes the PHP 7.2 → **8.1 in 3.2** requirement notes)
+- [Upgrading to 3.3.0](getting-started/maintenance/upgrading/3.3.0) (top-menu Access Policy keys)
 - [Upgrading to 2.8.2 / 2.8.3](getting-started/maintenance/upgrading/2.8.2) (security-related behavioural changes still relevant before jumping to 3.x)
 - Historical 2.x notes: [2.3](getting-started/maintenance/upgrading/2.3), [2.2](getting-started/maintenance/upgrading/2.2), [2.1](getting-started/maintenance/upgrading/2.1), [pre-2.0.5](getting-started/maintenance/upgrading/2.0.5), [2.0.0-rc2](getting-started/maintenance/upgrading/2.0.0-rc2)
 
@@ -100,5 +101,6 @@ See the note above about FTP clients that support directory merging.
 1. [Troubleshooting Upgrades](getting-started/maintenance/upgrading/troubleshooting)
 2. [Upgrading from 2.x to 3.0](getting-started/upgrading-to-3.0)
 3. [Server Requirements](getting-started/server-requirements)
-4. [Upgrading to 2.8.2 / 2.8.3](getting-started/maintenance/upgrading/2.8.2)
-5. [Upgrading from MODX Evolution](getting-started/maintenance/upgrading/evolution)
+4. [Upgrading to 3.3.0](getting-started/maintenance/upgrading/3.3.0)
+5. [Upgrading to 2.8.2 / 2.8.3](getting-started/maintenance/upgrading/2.8.2)
+6. [Upgrading from MODX Evolution](getting-started/maintenance/upgrading/evolution)

--- a/en/getting-started/maintenance/upgrading/3.3.0.md
+++ b/en/getting-started/maintenance/upgrading/3.3.0.md
@@ -1,0 +1,63 @@
+---
+title: Upgrading to 3.3.0
+sortorder: 95
+---
+
+MODX 3.3.0 aligns top-menu Access Policy keys with the pages and processors those menu items open. Parent folders no longer reuse a child page key, so denying System Settings no longer hides the whole Gear menu.
+
+Shipped in [modxcms/revolution#17012](https://github.com/modxcms/revolution/pull/17012). Refs [modxcms/revolution#14498](https://github.com/modxcms/revolution/issues/14498). Existing installs get the change through the `3.3.0-pl` upgrade scripts.
+
+See also the [Administrator Policy](building-sites/client-proofing/security/policies/permissions/administrator-policy) permission list.
+
+## Menu and page keys that now match
+
+| UI | Old menu key | New / shared key |
+| --- | --- | --- |
+| Reports → Error Log (menu, `system/event`, ErrorLog processors) | `view_eventlog` | `error_log_view` |
+| Gear → Menus (menu, `system/action`, Menu processors) | `actions` | `menus` |
+| User → Logout | `logout` | _(empty: logout is always allowed)_ |
+
+Extras or custom code that call `hasPermission('view_eventlog')` or `hasPermission('actions')` must switch to `error_log_view` and `menus`.
+
+The upgrade rewrites those menu rows. It does **not** grant `error_log_view` or `menus` to policies that only had the old menu aliases. A custom policy with only `view_eventlog` or `actions` loses that checkbox and does not gain the page key.
+
+## Parent menus get their own keys
+
+| Parent menu | Old shared key | New parent key | Child / page key (unchanged) |
+| --- | --- | --- | --- |
+| Media | `file_manager` | `menu_media` | `file_manager` (Media Browser) |
+| Access | `access_permissions` | `menu_access` | `access_permissions` (Resource Groups, ACLs, Flush Permissions) |
+| Gear (System) | `settings` | `menu_system` | `settings` (System Settings) |
+
+After upgrade, a user who had the old shared key also gets the matching parent key, so the parent stays visible. Deny the page key and keep the parent key if you want the folder open but the page blocked.
+
+Example: deny `settings`, keep `menu_system` → Gear stays visible, System Settings is blocked.
+
+Left as they were: `menu_site` (Content), `menu_reports`, `menu_user`, `menu_trash`, `components`.
+
+## Removed (dead) keys
+
+These keys are removed from `AdministratorTemplate`, core policies, and matching `modAccessPermission` rows:
+
+- `about`
+- `credits`
+- `export_static`
+- `logout` (policy checkbox; exit from the manager no longer checks it)
+- `view_eventlog`
+- `actions`
+- `menu_security`
+- `menu_support`
+- `menu_tools`
+
+## Custom policies checklist
+
+1. Grant `menu_media`, `menu_access`, and/or `menu_system` where users should see those parents.
+2. Keep `file_manager`, `access_permissions`, and `settings` for the actual pages.
+3. Replace `view_eventlog` with `error_log_view` and `actions` with `menus` if those users still need Error Log or Menus.
+4. Flush permissions after you edit policies (Security → Flush Permissions).
+
+## See also
+
+- [Permissions](building-sites/client-proofing/security/policies/permissions)
+- [Administrator Policy](building-sites/client-proofing/security/policies/permissions/administrator-policy)
+- [Menus](extending-modx/menus)

--- a/ru/building-sites/client-proofing/security/policies/permissions/administrator-policy.md
+++ b/ru/building-sites/client-proofing/security/policies/permissions/administrator-policy.md
@@ -5,21 +5,20 @@ translation: "building-sites/client-proofing/security/policies/permissions/admin
 
 ## Политика Администратора
 
-Эта политика упакована в MODX и предоставляется пользователям в контексте mgr, которые хотят иметь полный доступ к управлению содержимым MODX
+Эта политика упакована в MODX и предоставляется пользователям в контексте mgr, которые хотят иметь полный доступ к управлению содержимым MODX.
+
+С MODX 3.3.0 ключи верхнего меню совпадают со страницами, которые они открывают. Родители используют ключи `menu_*`. См. [Обновление до 3.3.0](getting-started/maintenance/upgrading/3.3.0).
 
 ## Разрешения по умолчанию
 
 | название                  | Описание доступа                                                                                                                                                                                            |
 | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| about                     | О странице.                                                                                                                                                                                                 |
-| access_permissions        | Любые связанные с разрешением доступа страницы и действия.                                                                                                                                                  |
+| access_permissions        | Страницы раздела Access с этим ключом (Resource Groups, ACL, Flush Permissions). Родитель Access использует `menu_access`.                                                                                  |
 | action_ok                 |
-| actions                   | Страница [действий](extending-modx/menus/actions "Действия и меню") .                                                                                                                                       |
 | change_password           | Пользователь может изменить свой пароль пользователя.                                                                                                                                                       |
 | change_profile            | Пользователь может изменить свой профиль.                                                                                                                                                                   |
 | Content_Types             | Страница [типов контента](building-sites/resources/content-types "Типы контента") .                                                                                                                         |
 | create                    | Базовый «создать» доступ к объектам.                                                                                                                                                                        |
-| credits                   | Просмотрите страницу «Кредиты».                                                                                                                                                                             |
 | customize_forms           | Просмотр и управление [настройкой](building-sites/client-proofing/form-customization "Настройка менеджера") страницы [менеджера](building-sites/client-proofing/form-customization "Настройка менеджера") . |
 | database                  | Страница Информация о системе                                                                                                                                                                               |
 | database_truncate         | Возможность усекать таблицу базы данных.                                                                                                                                                                    |
@@ -48,8 +47,8 @@ translation: "building-sites/client-proofing/security/policies/permissions/admin
 | edit_user                 | Для редактирования любого [пользователя](building-sites/client-proofing/security/users "пользователей") .                                                                                                   |
 | element_tree              | Возможность просмотра дерева элементов на левой панели.                                                                                                                                                     |
 | empty_cache               | Очистить кеш сайта.                                                                                                                                                                                         |
-| export_static             | Для экспорта сайта в статический HTML.                                                                                                                                                                      |
-| file_manager              | Использовать файловый менеджер, в том числе создание / удаление файлов.                                                                                                                                     |
+| error_log_view            | Просмотр Error Log в Reports (меню, `system/event` и процессоры ErrorLog).                                                                                                                                  |
+| file_manager              | Media Browser и связанные действия файлового менеджера. Родитель Media использует `menu_media`.                                                                                                             |
 | file_tree                 | Для просмотра дерева файлов на левой панели.                                                                                                                                                                |
 | flush_sessions            | Может сбрасывать сеансы по всему сайту.                                                                                                                                                                     |
 | frames                    | Чтобы использовать интерфейс диспетчера MODX на всех.                                                                                                                                                       |
@@ -60,9 +59,11 @@ translation: "building-sites/client-proofing/security/policies/permissions/admin
 | lexicons                  | Для редактирования или просмотра лексиконов и [интернационализации](extending-modx/internationalization "интернационализация") .                                                                            |
 | list                      | Базовое разрешение «перечислить» любой объект. Список означает получить коллекцию объектов.                                                                                                                 |
 | load                      | Базовое разрешение «загрузить» любой объект или иметь возможность вернуть его как экземпляр вообще.                                                                                                         |
-| logout                    | Чтобы можно было выйти из системы как пользователь.                                                                                                                                                         |
 | logs                      | Для просмотра журналов, таких как ошибки и журналы менеджера.                                                                                                                                               |
-| menus                     | Для редактирования или сохранения любых топовых пунктов меню.                                                                                                                                               |
+| menu_access               | Показать пункт главного меню Access.                                                                                                                                                                        |
+| menu_media                | Показать пункт главного меню Media.                                                                                                                                                                         |
+| menu_system               | Показать пункт главного меню шестерёнки (System). Не открывает System Settings (`settings`).                                                                                                                |
+| menus                     | Просмотр и управление Gear → Menus (`system/action` и процессоры Menu).                                                                                                                                     |
 | messages                  | Для отправки или просмотра любых личных сообщений.                                                                                                                                                          |
 | namespaces                | Для редактирования или просмотра [пространств имен](extending-modx/namespaces "Пространства имен") .                                                                                                        |
 | new_category              | Создать новую категорию.                                                                                                                                                                                    |
@@ -95,7 +96,7 @@ translation: "building-sites/client-proofing/security/policies/permissions/admin
 | save_tv                   | Сохранить любые [переменные шаблона](building-sites/elements/template-variables "Переменные шаблона") .                                                                                                     |
 | save_user                 | Сохранить любого [пользователя](building-sites/client-proofing/security/users "пользователей") .                                                                                                            |
 | search                    | Чтобы использовать страницу поиска.                                                                                                                                                                         |
-| settings                  | Для просмотра и редактирования любых настроек системы.                                                                                                                                                      |
+| settings                  | Просмотр и правка System Settings. Родитель шестерёнки использует `menu_system`.                                                                                                                            |
 | steal_locks               | Чтобы «украсть» блокировки, переопределяя текущую блокировку документа.                                                                                                                                     |
 | unlock_element_properties | Чтобы иметь возможность редактировать свойства по умолчанию для любого элемента.                                                                                                                            |
 | view                      | Базовое разрешение на «просмотр» любого объекта.                                                                                                                                                            |
@@ -103,7 +104,6 @@ translation: "building-sites/client-proofing/security/policies/permissions/admin
 | view_chunk                | Для просмотра любых [чанков](building-sites/elements/chunks "Куски") .                                                                                                                                      |
 | view_context              | Для просмотра любых [контекстов](building-sites/contexts "Контексты") .                                                                                                                                     |
 | view_document             | Для просмотра любых [ресурсов](building-sites/resources "Ресурсы") .                                                                                                                                        |
-| view_eventlog             | Для просмотра журнала событий.                                                                                                                                                                              |
 | view_offline              |
 | view_plugin               | Для просмотра любых [плагинов](extending-modx/plugins "Плагины") .                                                                                                                                          |
 | view_role                 | Для просмотра любых [ролей](building-sites/client-proofing/security/roles "Роли") .                                                                                                                         |
@@ -116,7 +116,7 @@ translation: "building-sites/client-proofing/security/policies/permissions/admin
 
 ## Пользовательские разрешения
 
-Если вы создали свои собственные действия и пункты меню [страницу настраиваемого менеджера](extending-modx/custom-manager-pages "Пользовательский менеджер страниц Учебникl"), то вы можете определить настраиваемые элементы разрешений при создании элемента меню (Система -> Действия -> Создать меню), который соответствует разрешения перечислены здесь.
+Если вы создали свои пункты меню (например [страницу настраиваемого менеджера](extending-modx/custom-manager-pages "Пользовательский менеджер страниц")), задайте ключ разрешения на пункте меню (System → Menus), совпадающий с разрешением в этой политике.
 
 ![](/2.x/en/building-sites/client-proofing/security/policies/permissions/modx+custom+permission.jpg)
 

--- a/ru/building-sites/client-proofing/security/policies/permissions/index.md
+++ b/ru/building-sites/client-proofing/security/policies/permissions/index.md
@@ -20,6 +20,8 @@ translation: "building-sites/client-proofing/security/policies/permissions"
 1. [Права Доступа - Политика Администратора](building-sites/client-proofing/security/policies/permissions/administrator-policy)
 2. [Права Доступа - Политика Ресурса](building-sites/client-proofing/security/policies/permissions/resource-policy)
 
+С MODX 3.3.0 родители верхнего меню и часть пунктов Reports/System используют отдельные ключи. См. [Обновление до 3.3.0](getting-started/maintenance/upgrading/3.3.0).
+
 ## Смотрите также
 
 1. [Пользователи](building-sites/client-proofing/security/users)

--- a/ru/getting-started/maintenance/upgrading.md
+++ b/ru/getting-started/maintenance/upgrading.md
@@ -71,6 +71,7 @@ translation: "getting-started/maintenance/upgrading"
 Изменения для конкретных версий см. на следующих страницах:
 
 - [Обновление с 2.x до 3.0](getting-started/upgrading-to-3.0) (обязательно при переходе 2.x → 3.x, включая заметки о PHP 7.2 → **8.1 в 3.2**)
+- [Обновление до 3.3.0](getting-started/maintenance/upgrading/3.3.0) (ключи Access Policy верхнего меню)
 - [Обновление до 2.8.2 / 2.8.3](getting-started/maintenance/upgrading/2.8.2) (изменения поведения, связанные с безопасностью, актуальны перед переходом на 3.x)
 - Исторические заметки по 2.x: [2.3](getting-started/maintenance/upgrading/2.3), [2.2](getting-started/maintenance/upgrading/2.2), [2.1](getting-started/maintenance/upgrading/2.1), [до 2.0.5](getting-started/maintenance/upgrading/2.0.5), [2.0.0-rc2](getting-started/maintenance/upgrading/2.0.0-rc2)
 
@@ -99,5 +100,6 @@ cp -fr modx-3.2.0-pl/* /www/public_html/modx
 1. [Решение проблем с обновлением](getting-started/maintenance/upgrading/troubleshooting)
 2. [Обновление с 2.x до 3.0](getting-started/upgrading-to-3.0)
 3. [Требования к серверу](getting-started/server-requirements)
-4. [Обновление до 2.8.2 / 2.8.3](getting-started/maintenance/upgrading/2.8.2)
-5. [Обновление с MODX Evolution](getting-started/maintenance/upgrading/evolution)
+4. [Обновление до 3.3.0](getting-started/maintenance/upgrading/3.3.0)
+5. [Обновление до 2.8.2 / 2.8.3](getting-started/maintenance/upgrading/2.8.2)
+6. [Обновление с MODX Evolution](getting-started/maintenance/upgrading/evolution)

--- a/ru/getting-started/maintenance/upgrading/3.3.0.md
+++ b/ru/getting-started/maintenance/upgrading/3.3.0.md
@@ -1,0 +1,64 @@
+---
+title: Обновление до 3.3.0
+translation: "getting-started/maintenance/upgrading/3.3.0"
+sortorder: 95
+---
+
+В MODX 3.3.0 ключи Access Policy для верхнего меню совпадают со страницами и процессорами, которые эти пункты открывают. Родительские папки больше не делят ключ с дочерней страницей. Отказ в System Settings больше не прячет всё меню шестерёнки.
+
+Поставлено в [modxcms/revolution#17012](https://github.com/modxcms/revolution/pull/17012). См. [modxcms/revolution#14498](https://github.com/modxcms/revolution/issues/14498). На существующих установках правки идут через скрипты апгрейда `3.3.0-pl`.
+
+Список разрешений: [политика администратора](building-sites/client-proofing/security/policies/permissions/administrator-policy).
+
+## Меню и страницы с одним ключом
+
+| Интерфейс | Старый ключ меню | Новый / общий ключ |
+| --- | --- | --- |
+| Reports → Error Log (меню, `system/event`, процессоры ErrorLog) | `view_eventlog` | `error_log_view` |
+| Gear → Menus (меню, `system/action`, процессоры Menu) | `actions` | `menus` |
+| User → Logout | `logout` | _(пусто: выход из менеджера всегда разрешён)_ |
+
+Дополнения и свой код с `hasPermission('view_eventlog')` или `hasPermission('actions')` должны перейти на `error_log_view` и `menus`.
+
+Апгрейд переписывает строки меню. Он **не** выдаёт `error_log_view` или `menus` политикам, у которых был только старый псевдоним меню. Кастомная политика только с `view_eventlog` или `actions` теряет этот чекбокс и не получает ключ страницы.
+
+## Отдельные ключи у родителей
+
+| Родитель | Старый общий ключ | Новый ключ родителя | Ключ страницы (без изменений) |
+| --- | --- | --- | --- |
+| Media | `file_manager` | `menu_media` | `file_manager` (Media Browser) |
+| Access | `access_permissions` | `menu_access` | `access_permissions` (Resource Groups, ACL, Flush Permissions) |
+| Gear (System) | `settings` | `menu_system` | `settings` (System Settings) |
+
+После апгрейда пользователь со старым общим ключом получает и ключ родителя. Родитель остаётся видимым. Заберите ключ страницы и оставьте ключ родителя, если папка должна быть открыта, а страница закрыта.
+
+Пример: отказ в `settings`, есть `menu_system` → шестерёнка видна, System Settings закрыт.
+
+Без изменений: `menu_site` (Content), `menu_reports`, `menu_user`, `menu_trash`, `components`.
+
+## Удалённые (мёртвые) ключи
+
+Эти ключи сняты с `AdministratorTemplate`, политик ядра и соответствующих строк `modAccessPermission`:
+
+- `about`
+- `credits`
+- `export_static`
+- `logout` (чекбокс политики. Выход из менеджера его больше не проверяет)
+- `view_eventlog`
+- `actions`
+- `menu_security`
+- `menu_support`
+- `menu_tools`
+
+## Чеклист для своих политик
+
+1. Выдайте `menu_media`, `menu_access` и/или `menu_system`, если пользователь должен видеть эти родители.
+2. Оставьте `file_manager`, `access_permissions` и `settings` для самих страниц.
+3. Замените `view_eventlog` на `error_log_view` и `actions` на `menus`, если Error Log или Menus ещё нужны.
+4. После правок политик сделайте Flush Permissions (Security → Flush Permissions).
+
+## Смотрите также
+
+- [Разрешения](building-sites/client-proofing/security/policies/permissions)
+- [Политика администратора](building-sites/client-proofing/security/policies/permissions/administrator-policy)
+- [Меню](extending-modx/menus)


### PR DESCRIPTION
## Description

Documents the top-menu Access Policy alignment from [modxcms/revolution#17012](https://github.com/modxcms/revolution/pull/17012) (needs-docs):

- New EN/RU upgrade notes: `getting-started/maintenance/upgrading/3.3.0`
- Menu/page keys: `view_eventlog` → `error_log_view`, `actions` → `menus`, logout menu gate cleared
- Parent keys: `menu_media`, `menu_access`, `menu_system` (pages keep `file_manager` / `access_permissions` / `settings`)
- Dead keys removed from Administrator Policy tables
- Upgrade behavior: parent visibility preserved; no privilege gain from old menu-only aliases
- Cross-links from upgrading index and permissions index (EN+RU)

Land this when/after Revolution #17012 merges into 3.x.

## Affected versions

3.x (3.3.0-pl upgrade path)

## Relevant issues

- Refs [modxcms/revolution#17012](https://github.com/modxcms/revolution/pull/17012)
- Refs [modxcms/revolution#14498](https://github.com/modxcms/revolution/issues/14498)