### PR TITLE
docs(events): Clarify OnWebLogout vs getUser() after logout

### DIFF
--- a/en/extending-modx/plugins/system-events/onmanagerlogout.md
+++ b/en/extending-modx/plugins/system-events/onmanagerlogout.md
@@ -21,6 +21,10 @@ Fires after a user is logged out of the manager and their context session is rem
 | **&** loginContext | The context key this logout is occurring in. **Passed by reference**                 |
 | **&** addContexts  | Additional contexts in which the logout is also occuring in. **Passed by reference** |
 
+## `$modx->getUser()` during OnManagerLogout
+
+Same logout processor as [OnWebLogout](extending-modx/plugins/system-events/onweblogout): session contexts are removed first, then the event fires, and `$modx->user` is not cleared. Prefer the event `$user` over `$modx->getUser()` for who logged out. See that page for details and a reload workaround.
+
 ## Example
 
 Such a plugin will write to the "Error log" who came out and where:

--- a/en/extending-modx/plugins/system-events/onweblogout.md
+++ b/en/extending-modx/plugins/system-events/onweblogout.md
@@ -6,7 +6,7 @@ _old_uri: "2.x/developing-in-modx/basic-development/plugins/system-events/onwebl
 
 ## Event: OnWebLogout
 
-Fires right after the user logs out of a context and their context session is removed.
+Fires after the logout processor removes the user's session contexts for a non-`mgr` context. Plugins cannot change whether the logout already happened.
 
 - Service: 3 - Web Access Events
 - Group: None
@@ -21,25 +21,47 @@ Fires right after the user logs out of a context and their context session is re
 | **&** loginContext | The context key this logout is occurring in. **Passed by reference**                 |
 | **&** addContexts  | Additional contexts in which the logout is also occuring in. **Passed by reference** |
 
+## `$modx->getUser()` during OnWebLogout
+
+The logout processor removes session contexts **before** it invokes `OnWebLogout`. For that context, `$modx->user->isAuthenticated($loginContext)` is already false.
+
+It does **not** clear or reload `$modx->user` before the event. `$modx->getUser()` short-circuits on the cached object and still returns the user who just logged out (same id). Code that calls `$modx->getUser()` (or fires other plugins that do) can look "still logged in" even though the session context is gone.
+
+Use the event `$user` parameter (or `$scriptProperties['user']`) for who logged out. Do not treat `$modx->getUser()` as the current session user during this event.
+
+If you need `$modx->getUser()` to reflect a logged-out request state, clear and reload after the session contexts are gone:
+
+```php
+$modx->user = null;
+$modx->getUser($loginContext, true);
+```
+
+The same processor path fires [OnManagerLogout](extending-modx/plugins/system-events/onmanagerlogout) for `mgr`, also without refreshing `$modx->user`. Core tracking: [modxcms/revolution#17015](https://github.com/modxcms/revolution/issues/17015).
+
 ## Example
 
-Such a plugin will display in the "Error log" who logged out and where:
+Log who logged out. Prefer the event `$user`, not `$modx->getUser()`:
 
 ```php
 <?php
 $eventName = $modx->event->name;
-switch($eventName) {
+switch ($eventName) {
     case 'OnWebLogout':
         $id = $user->get('id');
-        $modx->log(modX::LOG_LEVEL_ERROR, 'User with id logged out '.$id.' out of context '.$loginContext.' and these more '.print_r($addContexts));
+        $modx->log(
+            modX::LOG_LEVEL_ERROR,
+            'User with id ' . $id . ' logged out of context ' . $loginContext
+            . ' and these more ' . print_r($addContexts, true)
+        );
         break;
 }
 ```
 
 ## See Also
 
-- [OnBeforeWebLogout event](extending-modx/plugins/system-events/onbeforeweblogout "OnBeforeWebLogout")
-- [OnBeforeManagerLogout event](extending-modx/plugins/system-events/onbeforemanagerlogout "OnBeforeManagerLogout")
-- [OnManagerLogout event](extending-modx/plugins/system-events/onmanagerlogout "OnManagerLogout")
-- [System Events](extending-modx/plugins/system-events "System Events")
-- [Plugins](extending-modx/plugins "Plugins")
+- [OnBeforeWebLogout](extending-modx/plugins/system-events/onbeforeweblogout)
+- [OnBeforeManagerLogout](extending-modx/plugins/system-events/onbeforemanagerlogout)
+- [OnManagerLogout](extending-modx/plugins/system-events/onmanagerlogout)
+- [OnWebLogin](extending-modx/plugins/system-events/onweblogin)
+- [System Events](extending-modx/plugins/system-events)
+- [Plugins](extending-modx/plugins)

--- a/ru/extending-modx/plugins/system-events/onmanagerlogout.md
+++ b/ru/extending-modx/plugins/system-events/onmanagerlogout.md
@@ -20,6 +20,10 @@ translation: "extending-modx/plugins/system-events/onmanagerlogout"
 | **&** loginContext | Ключ контекста, в котором происходит выход из системы. **Передано по ссылке**                 |
 | **&** addContexts  | Дополнительные контексты, в которых также происходит выход из системы. **Передано по ссылке** |
 
+## `$modx->getUser()` во время OnManagerLogout
+
+Тот же процессор выхода, что и у [OnWebLogout](extending-modx/plugins/system-events/onweblogout): сначала снимаются session contexts, потом событие, `$modx->user` не сбрасывается. Для вышедшего пользователя берите `$user` из события, а не `$modx->getUser()`. Подробности и обходной путь на той странице.
+
 ## Пример
 
 Такой плагин запишет в "Журнал ошибок" кто и где вышел:

--- a/ru/extending-modx/plugins/system-events/onweblogout.md
+++ b/ru/extending-modx/plugins/system-events/onweblogout.md
@@ -5,10 +5,10 @@ translation: "extending-modx/plugins/system-events/onweblogout"
 
 ## Событие: OnWebLogout
 
-Запускается каждый раз, когда пользователь выходит из контекста. Сессия при этом удаляется.
+Вызывается после того, как процессор выхода снял session contexts пользователя во фронтенд-контексте (не `mgr`). Плагины не меняют уже произошедший выход.
 
-Служба: 3 - Web Access Service Events
-Группа: Нет
+- Служба: 3 - Web Access Events
+- Группа: Нет
 
 ## Параметры события
 
@@ -20,25 +20,47 @@ translation: "extending-modx/plugins/system-events/onweblogout"
 | **&** loginContext | Ключ контекста, в котором происходит выход из системы. **Передано по ссылке**                 |
 | **&** addContexts  | Дополнительные контексты, в которых также происходит выход из системы. **Передано по ссылке** |
 
+## `$modx->getUser()` во время OnWebLogout
+
+Процессор выхода снимает session contexts **до** вызова `OnWebLogout`. Для этого контекста `$modx->user->isAuthenticated($loginContext)` уже false.
+
+Перед событием процессор **не** обнуляет и не перезагружает `$modx->user`. `$modx->getUser()` берёт закэшированный объект и всё ещё возвращает пользователя, который только что вышел (тот же id). Код с `$modx->getUser()` (или другие плагины, которые его вызывают) может выглядеть «всё ещё в системе», хотя session context уже снят.
+
+Берите вышедшего пользователя из параметра события `$user` (или `$scriptProperties['user']`). Не считайте `$modx->getUser()` текущим пользователем сессии во время этого события.
+
+Если нужен именно `$modx->getUser()` в состоянии «разлогинен», сбросьте и перезагрузите после снятия session contexts:
+
+```php
+$modx->user = null;
+$modx->getUser($loginContext, true);
+```
+
+Тот же процессор для `mgr` вызывает [OnManagerLogout](extending-modx/plugins/system-events/onmanagerlogout) и тоже не обновляет `$modx->user`. Трекинг в ядре: [modxcms/revolution#17015](https://github.com/modxcms/revolution/issues/17015).
+
 ## Пример
 
-Такой плагин выведет в "Журнал ошибок" кто и где разлогинился:
+Записать в журнал ошибок, кто вышел. Берите `$user` из события, не `$modx->getUser()`:
 
 ```php
 <?php
 $eventName = $modx->event->name;
-switch($eventName) {
+switch ($eventName) {
     case 'OnWebLogout':
         $id = $user->get('id');
-        $modx->log(modX::LOG_LEVEL_ERROR, 'Вышел пользователь с id '.$id.' из контекста '.$loginContext.' и еще вот этих '.print_r($addContexts));
+        $modx->log(
+            modX::LOG_LEVEL_ERROR,
+            'Вышел пользователь с id ' . $id . ' из контекста ' . $loginContext
+            . ' и ещё вот этих ' . print_r($addContexts, true)
+        );
         break;
 }
 ```
 
-## Смотри также
+## Смотрите также
 
-- [OnBeforeWebLogout event](extending-modx/plugins/system-events/onbeforeweblogout "OnBeforeWebLogout")
-- [OnBeforeManagerLogout event](extending-modx/plugins/system-events/onbeforemanagerlogout "OnBeforeManagerLogout")
-- [OnManagerLogout event](extending-modx/plugins/system-events/onmanagerlogout "OnManagerLogout")
-- [Системные события](extending-modx/plugins/system-events "Системные события")
-- [Плагины](extending-modx/plugins "Плагины")
+- [OnBeforeWebLogout](extending-modx/plugins/system-events/onbeforeweblogout)
+- [OnBeforeManagerLogout](extending-modx/plugins/system-events/onbeforemanagerlogout)
+- [OnManagerLogout](extending-modx/plugins/system-events/onmanagerlogout)
+- [OnWebLogin](extending-modx/plugins/system-events/onweblogin)
+- [Системные события](extending-modx/plugins/system-events)
+- [Плагины](extending-modx/plugins)


### PR DESCRIPTION
## Description

Docs said OnWebLogout fires after logout, which led people to call `$modx->getUser()` and treat the request as still authenticated.

On Revolution, `Logout::process()` removes session contexts, then fires `OnWebLogout` / `OnManagerLogout` without clearing `$modx->user`. `getUser()` short-circuits on that object. Session auth is already gone (`isAuthenticated` false), but `getUser()` still returns the same user id.

Updates EN/RU OnWebLogout (and a short cross-note on OnManagerLogout): use the event `$user`, optional reload workaround, link to [modxcms/revolution#17015](https://github.com/modxcms/revolution/issues/17015).

Pairs with [#586](https://github.com/modxorg/Docs/pull/586) for OnWebLogin.

## Affected versions

Both (same Logout processor order on 2.x/3.x; verified against Revolution 3.x `Processors/Security/Logout.php`)

## Relevant issues

Fixes #427