### PR TITLE
docs: Extra 2.x to 3.x compatibility checklist (#301)

### DIFF
--- a/en/getting-started/upgrading-to-3.0/breaking-changes.md
+++ b/en/getting-started/upgrading-to-3.0/breaking-changes.md
@@ -15,6 +15,7 @@ The biggest breaking changes can be summarised as follows:
 - [It's no longer possible to use a custom core folder/path](getting-started/upgrading-to-3.0/core-folder)
 - [sqlsrv support has been removed](getting-started/upgrading-to-3.0/sqlsrv)
 - [A large number of (previously unnamespaced) classes have been renamed and moved](getting-started/upgrading-to-3.0/class-names), including processors and model classes.
+- [Checklist for Extra authors updating 2.x packages](getting-started/upgrading-to-3.0/extras)
 - [xPDO 3 ships via Composer with PSR-4 models; migrate custom packages](getting-started/upgrading-to-3.0/xpdo)
 - [All processors have been renamed, including base processors](getting-started/upgrading-to-3.0/processors)
 - [modAction and related functionality has been removed](getting-started/upgrading-to-3.0/actions)

--- a/en/getting-started/upgrading-to-3.0/extras.md
+++ b/en/getting-started/upgrading-to-3.0/extras.md
@@ -1,0 +1,86 @@
+---
+title: "Updating Extras for 3.0"
+description: "Checklist for Extra authors: namespaces, processors, xPDO models, menus, and CRC changes from MODX 2.x to 3.x."
+sortorder: 2
+---
+
+Site owners follow [Upgrading from 2.x to 3.0](getting-started/upgrading-to-3.0). This page is for people who ship or maintain transport packages.
+
+Compatible packages: [SiteDash extras list](https://sitedash.app/extras). Deep detail lives on the linked pages below. The [Collection](https://github.com/modxcms/Collections) notes from [theboxer](https://github.com/theboxer) (summarized on [modx.pro](https://modx.pro/development/19429)) show a real Extra that extends `modResource`.
+
+## Decide support scope
+
+| Goal | Approach |
+| --- | --- |
+| MODX 3 only | Use namespaced classes, PSR-4 models, `bootstrap.php`. Drop `require_once` of old core paths. |
+| One package for 2.x and 3.x | Branch on version (`$modx->version['version'] >= 3`), use class-name prefixes or dynamic parent classes. More work. Overview: [Modernizing Extras cheat sheet](https://modx.com/blog/modernizing-extras-conversion-cheat-sheet). |
+
+Global class aliases (`modResource`, `modObjectCreateProcessor`, …) still load by default in 3.0-3.2 via `load_deprecated_global_class_aliases`. They are scheduled to stop loading automatically in **3.3**. Plan namespaced code before that. See [Changed class names](getting-started/upgrading-to-3.0/class-names).
+
+## Checklist
+
+Work through each item that applies to your Extra.
+
+1. **PHP version**: target the PHP floor of the MODX line you support ([requirements](getting-started/upgrading-to-3.0/requirements)).
+2. **Class names**: replace short core names in `extends`, type hints, and `instanceof` with `MODX\Revolution\…` / `xPDO\…`. Tables: [Changed class names](getting-started/upgrading-to-3.0/class-names).
+3. **Processors**: extend the new processor namespaces. Remove flat-file processors. Drop `require_once` of `core/model/modx/modprocessor.class.php` and `…/processors/resource/*.class.php` (those paths are gone). Details: [Processors](getting-started/upgrading-to-3.0/processors).
+4. **xPDO models**: schema `package` as a PHP namespace, `version="3.0"`, regenerate `metadata.mysql.php`, call `addPackage` with a namespace prefix, register PSR-4. Guide: [xPDO 3](getting-started/upgrading-to-3.0/xpdo).
+5. **`bootstrap.php`**: optional file at the Extra core root (namespace path). Register autoload, `addPackage`, and DI services. See [Namespaces](extending-modx/namespaces) and [DI container](extending-modx/di-container).
+6. **Menus / CMP**: no `modAction`. Menu `action` is a controller name inside the namespace (`/manager/?namespace=myextra&a=home`). See [modAction and related](getting-started/upgrading-to-3.0/actions).
+7. **Manager JS**: `MODx.config.manager_language` → `MODx.config.cultureKey` ([Manager language](getting-started/upgrading-to-3.0/manager-language)).
+8. **HTTP client**: `modRestClient` is gone. Use the [HTTP service](extending-modx/services/http).
+9. **Build / install**: test install and upgrade on MODX 3. Prefer current scaffolds ([ModExtra3](https://github.com/modx-pro/ModExtra3) for 3.x). Package markdown attributes are parsed in 3.0 ([build script](extending-modx/transport-packages/build-script)).
+
+## Example: Extra that extends `modResource` (Collections pattern)
+
+If a custom resource must appear among `$modx->getDescendants(\MODX\Revolution\modResource::class)`, the schema `extends` value must use the namespaced core class.
+
+### Schema
+
+Before:
+
+```php
+<object class="CollectionContainer" extends="modResource">
+    <!-- columns unchanged -->
+</object>
+```
+
+After:
+
+```php
+<object class="CollectionContainer" extends="MODX\Revolution\modResource">
+    <!-- columns unchanged -->
+</object>
+```
+
+Rebuild the model so `metadata.mysql.php` picks up the change.
+
+### PHP class and processors
+
+Delete obsolete includes such as:
+
+```php
+require_once MODX_CORE_PATH . 'model/modx/modprocessor.class.php';
+require_once MODX_CORE_PATH . 'model/modx/processors/resource/create.class.php';
+require_once MODX_CORE_PATH . 'model/modx/processors/resource/update.class.php';
+```
+
+Extend the namespaced types instead:
+
+| 2.x | 3.x |
+| --- | --- |
+| `modResource` | `MODX\Revolution\modResource` |
+| `modResourceCreateProcessor` | `MODX\Revolution\Processors\Resource\Create` |
+| `modResourceUpdateProcessor` | `MODX\Revolution\Processors\Resource\Update` |
+
+Same idea for any custom `{ClassKey}CreateProcessor` / `{ClassKey}UpdateProcessor`. See [Processors](getting-started/upgrading-to-3.0/processors) and [Custom resource classes](building-sites/resources/custom-resources).
+
+## Related pages
+
+- [Breaking changes](getting-started/upgrading-to-3.0/breaking-changes)
+- [Changed class names](getting-started/upgrading-to-3.0/class-names)
+- [Processors](getting-started/upgrading-to-3.0/processors)
+- [xPDO 3](getting-started/upgrading-to-3.0/xpdo)
+- [modAction and related](getting-started/upgrading-to-3.0/actions)
+- [Namespaces](extending-modx/namespaces)
+- [Modernizing Extras (MODX blog series)](https://modx.com/blog/modernizing-extras-conversion-cheat-sheet)

--- a/en/getting-started/upgrading-to-3.0/index.md
+++ b/en/getting-started/upgrading-to-3.0/index.md
@@ -17,11 +17,14 @@ After you are on 2.6+, follow the [standard upgrading process](getting-started/m
 
 After upgrading the core and upgrading your extras, you may encounter some breaking changes that need to be addressed in extras or custom code.
 
+Extra authors: use the [Updating Extras for 3.0](getting-started/upgrading-to-3.0/extras) checklist (namespaces, processors, models, menus).
+
 - ⚠️ Important: upgrades from MODX older than **2.6.0** are not supported
 - ⚠️ Important: [the core folder must now always be located in the project root, and can no longer be renamed](getting-started/upgrading-to-3.0/core-folder)
 - ⚠️ Important: [MODX 3.0 required PHP 7.2; current 3.x (3.2+) requires PHP 8.1+](getting-started/upgrading-to-3.0/requirements)
 - ⚠️ Important: [sqlsrv support has been removed](getting-started/upgrading-to-3.0/sqlsrv)
 - [A list of breaking changes can be found here](getting-started/upgrading-to-3.0/breaking-changes), most notably [many core classes have been moved and renamed](getting-started/upgrading-to-3.0/class-names)
+- [Updating Extras for 3.0](getting-started/upgrading-to-3.0/extras)
 - [xPDO 3, Composer, and migrating custom models](getting-started/upgrading-to-3.0/xpdo)
 - [The manager language is now dynamic](getting-started/upgrading-to-3.0/manager-language)
 - [Various system settings have been removed or changed](getting-started/upgrading-to-3.0/system-settings)

--- a/ru/getting-started/upgrading-to-3.0/breaking-changes.md
+++ b/ru/getting-started/upgrading-to-3.0/breaking-changes.md
@@ -15,6 +15,7 @@ translation: "getting-started/upgrading-to-3.0/breaking-changes"
 - [Больше нельзя использовать свой каталог или путь к core](getting-started/upgrading-to-3.0/core-folder)
 - [Поддержка sqlsrv удалена](getting-started/upgrading-to-3.0/sqlsrv)
 - [Большое число (ранее без namespace) классов переименовано и перенесено](getting-started/upgrading-to-3.0/class-names), включая процессоры и классы моделей.
+- [Чеклист для авторов Extras при обновлении пакетов 2.x](getting-started/upgrading-to-3.0/extras)
 - [xPDO 3 через Composer и PSR-4; миграция кастомных пакетов](getting-started/upgrading-to-3.0/xpdo)
 - [Все процессоры переименованы, включая базовые](getting-started/upgrading-to-3.0/processors)
 - [modAction и связанный функционал удалены](getting-started/upgrading-to-3.0/actions)

--- a/ru/getting-started/upgrading-to-3.0/extras.md
+++ b/ru/getting-started/upgrading-to-3.0/extras.md
@@ -1,0 +1,87 @@
+---
+title: "Обновление дополнений для 3.0"
+description: "Чеклист для авторов Extras: пространства имён, процессоры, модели xPDO, меню и CRC при переходе с MODX 2.x на 3.x."
+translation: "getting-started/upgrading-to-3.0/extras"
+sortorder: 2
+---
+
+Владельцы сайтов идут по [Обновлению с 2.x до 3.0](getting-started/upgrading-to-3.0). Эта страница для тех, кто собирает и сопровождает transport-пакеты.
+
+Список совместимых пакетов: [SiteDash](https://sitedash.app/extras). Подробности на связанных страницах ниже. Заметки [theboxer](https://github.com/theboxer) по [Collection](https://github.com/modxcms/Collections) (сводка на [modx.pro](https://modx.pro/development/19429)) показывают Extra, который расширяет `modResource`.
+
+## Какой объём поддержки
+
+| Цель | Подход |
+| --- | --- |
+| Только MODX 3 | Имена с namespace, модели PSR-4, `bootstrap.php`. Убрать `require_once` старых путей ядра. |
+| Один пакет на 2.x и 3.x | Ветвление по версии (`$modx->version['version'] >= 3`), префиксы имён классов или динамические родительские классы. Больше работы. Обзор: [Modernizing Extras cheat sheet](https://modx.com/blog/modernizing-extras-conversion-cheat-sheet). |
+
+Глобальные алиасы (`modResource`, `modObjectCreateProcessor`, …) в 3.0-3.2 по умолчанию ещё подключаются через `load_deprecated_global_class_aliases`. Автоподключение планируют убрать в **3.3**. К этому моменту код лучше перевести на namespace. См. [Изменённые имена классов](getting-started/upgrading-to-3.0/class-names).
+
+## Чеклист
+
+Пройдите пункты, которые относятся к вашему Extra.
+
+1. **Версия PHP**: ориентируйтесь на минимум той линейки MODX, которую поддерживаете ([требования](getting-started/upgrading-to-3.0/requirements)).
+2. **Имена классов**: в `extends`, type hint и `instanceof` вместо коротких имён ядра используйте `MODX\Revolution\…` / `xPDO\…`. Таблицы: [Изменённые имена классов](getting-started/upgrading-to-3.0/class-names).
+3. **Процессоры**: наследуйтесь от новых namespace процессоров. Flat-file процессоры уберите. Удалите `require_once` на `core/model/modx/modprocessor.class.php` и `…/processors/resource/*.class.php` (эти пути исчезли). Подробнее: [Процессоры](getting-started/upgrading-to-3.0/processors).
+4. **Модели xPDO**: в схеме `package` это PHP-namespace, `version="3.0"`, пересоберите `metadata.mysql.php`, вызовите `addPackage` с префиксом namespace, зарегистрируйте PSR-4. Гайд: [xPDO 3](getting-started/upgrading-to-3.0/xpdo).
+5. **`bootstrap.php`**: необязательный файл в корне Extra (путь namespace). Autoload, `addPackage`, сервисы DI. См. [Пространства имён](extending-modx/namespaces) и [DI-контейнер](extending-modx/di-container).
+6. **Меню / CMP**: без `modAction`. В меню `action` это имя контроллера в namespace (`/manager/?namespace=myextra&a=home`). См. [modAction и связанные](getting-started/upgrading-to-3.0/actions).
+7. **JS менеджера**: `MODx.config.manager_language` → `MODx.config.cultureKey` ([Язык менеджера](getting-started/upgrading-to-3.0/manager-language)).
+8. **HTTP-клиент**: `modRestClient` удалён. Используйте [HTTP-сервис](extending-modx/services/http).
+9. **Сборка / установка**: проверьте install и upgrade на MODX 3. Для 3.x удобнее актуальная заготовка ([ModExtra3](https://github.com/modx-pro/ModExtra3)). В 3.0 Markdown в атрибутах пакета разбирается ([скрипт сборки](extending-modx/transport-packages/build-script)).
+
+## Пример: Extra расширяет `modResource` (паттерн Collections)
+
+Если кастомный ресурс должен попадать в `$modx->getDescendants(\MODX\Revolution\modResource::class)`, в схеме у `extends` нужно полное имя класса ядра.
+
+### Схема
+
+Было:
+
+```php
+<object class="CollectionContainer" extends="modResource">
+    <!-- колонки без изменений -->
+</object>
+```
+
+Стало:
+
+```php
+<object class="CollectionContainer" extends="MODX\Revolution\modResource">
+    <!-- колонки без изменений -->
+</object>
+```
+
+Пересоберите модель, чтобы обновился `metadata.mysql.php`.
+
+### PHP-класс и процессоры
+
+Уберите устаревшие подключения, например:
+
+```php
+require_once MODX_CORE_PATH . 'model/modx/modprocessor.class.php';
+require_once MODX_CORE_PATH . 'model/modx/processors/resource/create.class.php';
+require_once MODX_CORE_PATH . 'model/modx/processors/resource/update.class.php';
+```
+
+Наследуйтесь от типов с namespace:
+
+| 2.x | 3.x |
+| --- | --- |
+| `modResource` | `MODX\Revolution\modResource` |
+| `modResourceCreateProcessor` | `MODX\Revolution\Processors\Resource\Create` |
+| `modResourceUpdateProcessor` | `MODX\Revolution\Processors\Resource\Update` |
+
+То же для любых `{ClassKey}CreateProcessor` / `{ClassKey}UpdateProcessor`. См. [Процессоры](getting-started/upgrading-to-3.0/processors) и [пользовательские классы ресурсов](building-sites/resources/custom-resources).
+
+## Связанные страницы
+
+- [Критические изменения](getting-started/upgrading-to-3.0/breaking-changes)
+- [Изменённые имена классов](getting-started/upgrading-to-3.0/class-names)
+- [Процессоры](getting-started/upgrading-to-3.0/processors)
+- [xPDO 3](getting-started/upgrading-to-3.0/xpdo)
+- [modAction и связанные](getting-started/upgrading-to-3.0/actions)
+- [Пространства имён](extending-modx/namespaces)
+- [Modernizing Extras (серия в блоге MODX)](https://modx.com/blog/modernizing-extras-conversion-cheat-sheet)

--- a/ru/getting-started/upgrading-to-3.0/index.md
+++ b/ru/getting-started/upgrading-to-3.0/index.md
@@ -16,11 +16,14 @@ translation: "getting-started/upgrading-to-3.0"
 
 После обновления ядра и дополнений могут проявиться критические изменения, которые нужно исправить в дополнениях или своём коде.
 
+Авторам Extras: чеклист [Обновление дополнений для 3.0](getting-started/upgrading-to-3.0/extras) (namespace, процессоры, модели, меню).
+
 - ⚠️ Важно: обновление с MODX старше **2.6.0** не поддерживается
 - ⚠️ Важно: [каталог core теперь всегда должен находиться в корне проекта и больше не может быть переименован](getting-started/upgrading-to-3.0/core-folder)
 - ⚠️ Важно: [MODX 3.0 требовал PHP 7.2, текущие 3.x (3.2+) требуют PHP 8.1+](getting-started/upgrading-to-3.0/requirements)
 - ⚠️ Важно: [поддержка sqlsrv удалена](getting-started/upgrading-to-3.0/sqlsrv)
 - [Список критических изменений](getting-started/upgrading-to-3.0/breaking-changes), в частности [многие классы ядра перенесены и переименованы](getting-started/upgrading-to-3.0/class-names)
+- [Обновление дополнений для 3.0](getting-started/upgrading-to-3.0/extras)
 - [xPDO 3, Composer и миграция кастомных моделей](getting-started/upgrading-to-3.0/xpdo)
 - [Язык менеджера теперь динамический](getting-started/upgrading-to-3.0/manager-language)
 - [Различные системные настройки удалены или изменены](getting-started/upgrading-to-3.0/system-settings)


### PR DESCRIPTION
## Description

New page for Extra authors updating packages from MODX 2.x to 3.x (issue asked for a package counterpart to the core upgrade docs).

- Checklist: class names, processors, xPDO/`bootstrap.php`, menus (`modAction` gone), manager JS, HTTP client, build
- Collections-style example (namespaced `extends`, drop old `require_once`, resource processor classes), based on [modx.pro/development/19429](https://modx.pro/development/19429) / theboxer notes
- Linked from upgrading-to-3.0 index and breaking-changes (EN + RU)

## Affected versions

- 3.x

## Relevant issues

Fixes #301